### PR TITLE
fix stylesheet ordering

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,10 @@
-import type { Metadata } from "next";
-import "./globals.css";
-import Navbar from "../components/Navbar"; // Adjust the path as needed
-import Footer from "../components/Footer";
 import "@mantine/core/styles.css";
 import "@mantine/notifications/styles.css"
+import "./globals.css";
+
+import type { Metadata } from "next";
+import Navbar from "../components/Navbar"; // Adjust the path as needed
+import Footer from "../components/Footer";
 import localFont from "next/font/local";
 import { NextFontWithVariable } from "next/dist/compiled/@next/font";
 import { CampStarfishFont, campStarfishFonts } from "@/styles/fonts";


### PR DESCRIPTION
- Changed order of Mantine & Tailwind stylesheets to resolve issues with Mantine styles overriding Tailwind utility classes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized import organization and removed duplicate dependency declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->