### PR TITLE
remove dark mode & globals.css styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,14 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-body {
-  color: var(--foreground);
-  background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
-}


### PR DESCRIPTION
- Removed dark mode presets in globals.css since we are not designing this site with dark mode in mind
- Removed content globals.css styling since styling for colors & typography will be done through Mantine
- globals.css now only contains Tailwind setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified global styling by migrating to Tailwind utilities exclusively
  * Removed custom color and font declarations for consistent theming

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->