### PR TITLE
hotfix(security): upgrade Next.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "lucide-react": "^0.482.0",
         "mime-types": "^3.0.1",
         "moment": "^2.30.1",
-        "next": "^15.5.8",
+        "next": "^15.5.9",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-dropzone": "^14.3.8",
@@ -2341,9 +2341,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.8",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.8.tgz",
-      "integrity": "sha512-ejZHa3ogTxcy851dFoNtfB5B2h7AbSAtHbR5CymUlnz4yW1QjHNufVpvTu8PTnWBKFKjrd4k6Gbi2SsCiJKvxw==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.9.tgz",
+      "integrity": "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -9117,12 +9117,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.5.8",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.8.tgz",
-      "integrity": "sha512-Tma2R50eiM7Fx6fbDeHiThq7sPgl06mBr76j6Ga0lMFGrmaLitFsy31kykgb8Z++DR2uIEKi2RZ0iyjIwFd15Q==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
+      "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.8",
+        "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lucide-react": "^0.482.0",
     "mime-types": "^3.0.1",
     "moment": "^2.30.1",
-    "next": "^15.5.8",
+    "next": "^15.5.9",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-dropzone": "^14.3.8",


### PR DESCRIPTION
- Patched Next.js version for [React vulnerability](https://nextjs.org/blog/security-update-2025-12-11) was updated from 15.5.8 to 15.5.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Next.js to the latest patch version for improved stability and ongoing maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->