### PR TITLE
refactor(firestore): replace Firestore data converters with custom mapper functions

### DIFF
--- a/functions/src/data/firestore/albumItemReports.ts
+++ b/functions/src/data/firestore/albumItemReports.ts
@@ -1,73 +1,65 @@
 import { adminDb } from "../../config/firebaseAdminConfig";
 import { AlbumItemReport } from "@/types/albums/albumTypes";
 import { AlbumItemReportDoc } from "@/data/firestore/types/documents";
-import { 
-  Transaction, 
-  WriteBatch, 
-  FirestoreDataConverter, 
-  WithFieldValue, 
-  QueryDocumentSnapshot, 
+import {
+  Transaction,
+  WriteBatch,
   DocumentReference,
-  CollectionReference
+  CollectionReference,
+  DocumentSnapshot,
+  QueryDocumentSnapshot
 } from "firebase-admin/firestore";
 import { getDoc, setDoc, updateDoc, deleteDoc, executeQuery } from "./firestoreAdminOperations";
 import { RootLevelCollection, AlbumsSubcollection, AlbumItemsSubcollection } from "@/data/firestore/types/collections";
 import { v4 as uuid } from "uuid";
 
-const albumItemReportFirestoreConverter: FirestoreDataConverter<AlbumItemReport, AlbumItemReportDoc> = {
-  toFirestore: (report: WithFieldValue<AlbumItemReport>): WithFieldValue<AlbumItemReportDoc> => {
-    const { id, albumItemId, albumId, ...dto } = report;
-    return dto;
-  },
-  fromFirestore: (snapshot: QueryDocumentSnapshot<AlbumItemReportDoc, AlbumItemReportDoc>): AlbumItemReport => {
-    return ({
-      id: snapshot.ref.id,
-      albumItemId: snapshot.ref.parent.parent!.id,
-      albumId: snapshot.ref.parent.parent!.parent.parent!.id,
-      ...snapshot.data()
-    });
+function fromFirestore(snapshot: DocumentSnapshot<AlbumItemReportDoc, AlbumItemReportDoc> | QueryDocumentSnapshot<AlbumItemReportDoc, AlbumItemReportDoc>): AlbumItemReport {
+  if (!snapshot.exists) { throw Error("Document not found"); };
+  return {
+    id: snapshot.ref.id,
+    albumItemId: snapshot.ref.parent.parent!.id,
+    albumId: snapshot.ref.parent.parent!.parent.parent!.id,
+    ...snapshot.data() as AlbumItemReportDoc
   }
-};
+}
 
 export async function getAlbumItemReportDocById(albumId: string, albumItemId: string, reportId: string, transaction?: Transaction): Promise<AlbumItemReport> {
-  return await getDoc<AlbumItemReport, AlbumItemReportDoc>(
-    adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId).collection(AlbumItemsSubcollection.REPORTS).doc(reportId) as DocumentReference<AlbumItemReport, AlbumItemReportDoc>, 
-    albumItemReportFirestoreConverter, 
+  const snapshot = await getDoc<AlbumItemReportDoc>(
+    adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId).collection(AlbumItemsSubcollection.REPORTS).doc(reportId) as DocumentReference<AlbumItemReportDoc, AlbumItemReportDoc>,
     transaction
   );
+  return fromFirestore(snapshot);
 }
 
 export async function getAlbumItemReportDocsByImageId(albumId: string, albumItemId: string, transaction?: Transaction): Promise<AlbumItemReport[]> {
-  return await executeQuery<AlbumItemReport, AlbumItemReportDoc>(
-    adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId).collection(AlbumItemsSubcollection.REPORTS) as CollectionReference<AlbumItemReport, AlbumItemReportDoc>,
-    albumItemReportFirestoreConverter,
+  const snapshots = await executeQuery<AlbumItemReportDoc>(
+    adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId).collection(AlbumItemsSubcollection.REPORTS) as CollectionReference<AlbumItemReportDoc, AlbumItemReportDoc>,
     { transaction }
   );
+  return snapshots.map(fromFirestore);
 }
 
 export async function createAlbumItemReportDoc(albumId: string, albumItemId: string, report: AlbumItemReportDoc, instance?: Transaction | WriteBatch): Promise<string> {
   const reportId = uuid();
-  await setDoc<AlbumItemReport, AlbumItemReportDoc>(
-    adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId).collection(AlbumItemsSubcollection.REPORTS).doc(reportId) as DocumentReference<AlbumItemReport, AlbumItemReportDoc>, 
-    { id: reportId, albumItemId, albumId, ...report }, 
-    albumItemReportFirestoreConverter, 
+  await setDoc<AlbumItemReportDoc>(
+    adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId).collection(AlbumItemsSubcollection.REPORTS).doc(reportId) as DocumentReference<AlbumItemReportDoc, AlbumItemReportDoc>,
+    report,
     { instance }
   );
   return reportId;
 }
 
 export async function updateAlbumItemReportDoc(albumId: string, albumItemId: string, reportId: string, updates: Partial<AlbumItemReportDoc>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<AlbumItemReport, AlbumItemReportDoc>(
-    adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId).collection(AlbumItemsSubcollection.REPORTS).doc(reportId) as DocumentReference<AlbumItemReport, AlbumItemReportDoc>, 
-    updates, 
-    albumItemReportFirestoreConverter, 
+  await updateDoc<AlbumItemReportDoc>(
+    adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId).collection(AlbumItemsSubcollection.REPORTS).doc(reportId) as DocumentReference<AlbumItemReportDoc, AlbumItemReportDoc>,
+    updates,
     instance
   );
 }
 
 export async function deleteAlbumItemReportDoc(albumId: string, albumItemId: string, reportId: string, instance?: Transaction | WriteBatch): Promise<void> {
-  await deleteDoc<AlbumItemReport, AlbumItemReportDoc>(
-    adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId).collection(AlbumItemsSubcollection.REPORTS).doc(reportId) as DocumentReference<AlbumItemReport, AlbumItemReportDoc>, 
+  await deleteDoc<AlbumItemReportDoc>(
+    adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId).collection(AlbumItemsSubcollection.REPORTS).doc(reportId) as DocumentReference<AlbumItemReportDoc, AlbumItemReportDoc>,
     instance
   );
 }

--- a/functions/src/data/firestore/albumItems.ts
+++ b/functions/src/data/firestore/albumItems.ts
@@ -1,30 +1,32 @@
 import { AlbumItem } from "@/types/albums/albumTypes";
 import { AlbumItemDoc } from "@/data/firestore/types/documents";
-import { Transaction, WriteBatch, FirestoreDataConverter, WithFieldValue, QueryDocumentSnapshot, DocumentReference } from "firebase-admin/firestore";
+import { Transaction, WriteBatch, QueryDocumentSnapshot, DocumentReference, DocumentSnapshot } from "firebase-admin/firestore";
 import { getDoc, createDoc, updateDoc, deleteDoc } from "./firestoreAdminOperations"
 import { AlbumsSubcollection, RootLevelCollection } from "@/data/firestore/types/collections";
 import { adminDb } from "../../config/firebaseAdminConfig";
 
-const albumItemFirestoreConverter: FirestoreDataConverter<AlbumItem, AlbumItemDoc> = {
-  toFirestore: (image: WithFieldValue<AlbumItem>): WithFieldValue<AlbumItemDoc> => {
-    const { id, albumId, ...dto } = image;
-    return dto;
-  },
-  fromFirestore: (snapshot: QueryDocumentSnapshot<AlbumItemDoc, AlbumItemDoc>): AlbumItem => ({ id: snapshot.ref.id, albumId: snapshot.ref.parent.parent!.id, ...snapshot.data() })
+function fromFirestore(snapshot: DocumentSnapshot<AlbumItemDoc, AlbumItemDoc> | QueryDocumentSnapshot<AlbumItemDoc, AlbumItemDoc>): AlbumItem {
+  if (!snapshot.exists) { throw Error("Document not found"); };
+  return {
+    id: snapshot.ref.id,
+    albumId: snapshot.ref.parent.parent!.id,
+    ...snapshot.data() as AlbumItemDoc
+  }
 }
 
 export async function getAlbumItemById(albumId: string, albumItemId: string, transaction?: Transaction): Promise<AlbumItem> {
-  return await getDoc<AlbumItem, AlbumItemDoc>(adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId) as DocumentReference<AlbumItem, AlbumItemDoc>, albumItemFirestoreConverter, transaction);
+  const snapshot = await getDoc<AlbumItemDoc>(adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId) as DocumentReference<AlbumItemDoc, AlbumItemDoc>, transaction);
+  return fromFirestore(snapshot);
 }
 
-export async function createAlbumItem(albumId: string, albumItemId: string, image: AlbumItemDoc, instance?: Transaction | WriteBatch): Promise<void> {
-  await createDoc(adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId) as DocumentReference<AlbumItem, AlbumItemDoc>, { id: albumItemId, albumId, ...image }, albumItemFirestoreConverter, instance);
+export async function createAlbumItem(albumId: string, albumItemId: string, albumItem: AlbumItemDoc, instance?: Transaction | WriteBatch): Promise<void> {
+  await createDoc<AlbumItemDoc>(adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId) as DocumentReference<AlbumItemDoc, AlbumItemDoc>, albumItem, instance);
 }
 
 export async function updateAlbumItem(albumId: string, albumItemId: string, updates: Partial<AlbumItemDoc>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<AlbumItem, AlbumItemDoc>(adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId) as DocumentReference<AlbumItem, AlbumItemDoc>, updates, albumItemFirestoreConverter, instance);
+  await updateDoc<AlbumItemDoc>(adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId) as DocumentReference<AlbumItemDoc, AlbumItemDoc>, updates, instance);
 }
 
 export async function deleteAlbumItem(albumId: string, albumItemId: string, instance?: Transaction | WriteBatch): Promise<void> {
-  await deleteDoc<AlbumItem, AlbumItemDoc>(adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId) as DocumentReference<AlbumItem, AlbumItemDoc>, instance);
+  await deleteDoc<AlbumItemDoc>(adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId).collection(AlbumsSubcollection.ALBUM_ITEMS).doc(albumItemId) as DocumentReference<AlbumItemDoc, AlbumItemDoc>, instance);
 }

--- a/functions/src/data/firestore/albums.ts
+++ b/functions/src/data/firestore/albums.ts
@@ -3,31 +3,32 @@ import { AlbumDoc } from "@/data/firestore/types/documents";
 import { v4 as uuid } from "uuid";
 import { RootLevelCollection } from "@/data/firestore/types/collections";
 import { createDoc, deleteDoc, getDoc, updateDoc } from "./firestoreAdminOperations";
-import { DocumentReference, FirestoreDataConverter, QueryDocumentSnapshot, Transaction, UpdateData, WithFieldValue, WriteBatch } from "firebase-admin/firestore";
+import { DocumentReference, DocumentSnapshot, QueryDocumentSnapshot, Transaction, UpdateData, WriteBatch } from "firebase-admin/firestore";
 import { adminDb } from "../../config/firebaseAdminConfig";
 
-const albumFirestoreConverter: FirestoreDataConverter<Album, AlbumDoc> = {
-  toFirestore: (album: WithFieldValue<Album>): WithFieldValue<AlbumDoc> => {
-    const { id, ...dto } = album;
-    return dto;
-  },
-  fromFirestore: (snapshot: QueryDocumentSnapshot<AlbumDoc, AlbumDoc>): Album => ({ id: snapshot.ref.id, ...snapshot.data() })
-};
+function fromFirestore(snapshot: DocumentSnapshot<AlbumDoc, AlbumDoc> | QueryDocumentSnapshot<AlbumDoc, AlbumDoc>): Album {
+  if (!snapshot.exists) { throw Error("Document not found"); }
+  return {
+    id: snapshot.ref.id,
+    ...snapshot.data() as AlbumDoc
+  }
+}
 
 export async function getAlbumById(id: string, transaction?: Transaction): Promise<Album> {
-  return await getDoc<Album, AlbumDoc>(adminDb.collection(RootLevelCollection.ALBUMS).doc(id) as DocumentReference<Album, AlbumDoc>, albumFirestoreConverter, transaction);
+  const snapshot = await getDoc<AlbumDoc>(adminDb.collection(RootLevelCollection.ALBUMS).doc(id) as DocumentReference<AlbumDoc, AlbumDoc>, transaction);
+  return fromFirestore(snapshot);
 }
 
 export async function createAlbum(album: AlbumDoc, instance?: Transaction | WriteBatch): Promise<string> {
   const albumId = uuid();
-  await createDoc<Album, AlbumDoc>(adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId) as DocumentReference<Album, AlbumDoc>, { id: albumId, ...album }, albumFirestoreConverter, instance);
+  await createDoc<AlbumDoc>(adminDb.collection(RootLevelCollection.ALBUMS).doc(albumId) as DocumentReference<AlbumDoc, AlbumDoc>, album, instance);
   return albumId;
 }
 
 export async function updateAlbum(id: string, updates: UpdateData<AlbumDoc>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<Album, AlbumDoc>(adminDb.collection(RootLevelCollection.ALBUMS).doc(id) as DocumentReference<Album, AlbumDoc>, updates, albumFirestoreConverter, instance);
+  await updateDoc<AlbumDoc>(adminDb.collection(RootLevelCollection.ALBUMS).doc(id) as DocumentReference<AlbumDoc, AlbumDoc>, updates, instance);
 }
 
 export async function deleteAlbum(id: string, instance?: Transaction | WriteBatch): Promise<void> {
-  await deleteDoc<Album, AlbumDoc>(adminDb.collection(RootLevelCollection.ALBUMS).doc(id) as DocumentReference<Album, AlbumDoc>, instance);
+  await deleteDoc<AlbumDoc>(adminDb.collection(RootLevelCollection.ALBUMS).doc(id) as DocumentReference<AlbumDoc, AlbumDoc>, instance);
 }

--- a/functions/src/data/firestore/firestoreAdminOperations.ts
+++ b/functions/src/data/firestore/firestoreAdminOperations.ts
@@ -1,13 +1,12 @@
-import { AggregateField, AggregateType, CollectionGroup, CollectionReference, DocumentData, DocumentReference, DocumentSnapshot, FirestoreDataConverter, GrpcStatus, PartialWithFieldValue, Query, SetOptions, Transaction, UpdateData, WhereFilterOp, WithFieldValue, WriteBatch } from "firebase-admin/firestore";
+import { AggregateField, AggregateType, CollectionGroup, CollectionReference, DocumentData, DocumentReference, DocumentSnapshot, GrpcStatus, PartialWithFieldValue, Query, SetOptions, Transaction, UpdateData, WhereFilterOp, WithFieldValue, WriteBatch } from "firebase-admin/firestore";
 import { isFirebaseError } from "../../types/error";
 import { Collection } from "@/data/firestore/types/collections";
 import { adminDb } from "../../config/firebaseAdminConfig";
 import { DistributiveKeyof } from "@/utils/types/typeUtils";
 
-export async function getDoc<AppModelType, DbModelType extends DocumentData>(ref: DocumentReference<AppModelType, DbModelType>, converter: FirestoreDataConverter<AppModelType, DbModelType>, transaction?: Transaction): Promise<AppModelType> {
-  let doc: DocumentSnapshot<AppModelType, DbModelType>;
+export async function getDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, transaction?: Transaction): Promise<DbModelType> {
+  let doc: DocumentSnapshot<DbModelType, DbModelType>;
   try {
-    ref = ref.withConverter(converter);
     doc = await (transaction ? transaction.get(ref) : ref.get());
   } catch {
     throw Error("Error getting document");
@@ -19,9 +18,8 @@ export async function getDoc<AppModelType, DbModelType extends DocumentData>(ref
   return doc.data()!;
 }
 
-export async function createDoc<AppModelType, DbModelType extends DocumentData>(ref: DocumentReference<AppModelType, DbModelType>, data: WithFieldValue<AppModelType>, converter: FirestoreDataConverter<AppModelType, DbModelType>, instance?: Transaction | WriteBatch): Promise<void> {
+export async function createDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, data: WithFieldValue<DbModelType>, instance?: Transaction | WriteBatch): Promise<void> {
   try {
-    ref = ref.withConverter(converter);
     await (instance ? instance.create(ref, data) : ref.create(data));
   } catch (error: unknown) {
     if (isFirebaseError(error) && error.code === GrpcStatus.ALREADY_EXISTS) {
@@ -40,28 +38,26 @@ interface SetDocOverwriteOptions {
   instance?: Transaction | WriteBatch;
 }
 
-export async function setDoc<AppModelType, DbModelType extends DocumentData>(ref: DocumentReference<AppModelType, DbModelType>, data: WithFieldValue<AppModelType>, converter: FirestoreDataConverter<AppModelType, DbModelType>, options?: SetDocOverwriteOptions): Promise<void>
-export async function setDoc<AppModelType, DbModelType extends DocumentData>(ref: DocumentReference<AppModelType, DbModelType>, data: PartialWithFieldValue<AppModelType>, converter: FirestoreDataConverter<AppModelType, DbModelType>, options: SetDocMergeOptions): Promise<void>
-export async function setDoc<AppModelType, DbModelType extends DocumentData>(ref: DocumentReference<AppModelType, DbModelType>, data: WithFieldValue<AppModelType> | PartialWithFieldValue<AppModelType>, converter: FirestoreDataConverter<AppModelType, DbModelType>, options?: SetDocOptions): Promise<void> {
+export async function setDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, data: WithFieldValue<DbModelType>, options?: SetDocOverwriteOptions): Promise<void>
+export async function setDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, data: PartialWithFieldValue<DbModelType>, options: SetDocMergeOptions): Promise<void>
+export async function setDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, data: WithFieldValue<DbModelType> | PartialWithFieldValue<DbModelType>, options?: SetDocOptions): Promise<void> {
   try {
-    ref = ref.withConverter(converter);
     options = options ?? {};
     const { instance } = options;
     if ('mergeOptions' in options) {
       // @ts-expect-error - both Transaction & WriteBatch have a set with the same signature, but TypeScript fails to recognize that
-      await (instance ? instance.set(ref, data, options.mergeOptions) : ref.set(data as PartialWithFieldValue<AppModelType>, options.mergeOptions));
+      await (instance ? instance.set(ref, data, options.mergeOptions) : ref.set(data as PartialWithFieldValue<DbModelType>, options.mergeOptions));
     } else {
       // @ts-expect-error - both Transaction & WriteBatch have a set with the same signature, but TypeScript fails to recognize that
-      await (instance ? instance.set(ref, data) : ref.set(data as WithFieldValue<AppModelType>));
+      await (instance ? instance.set(ref, data) : ref.set(data as WithFieldValue<DbModelType>));
     }
   } catch {
     throw Error("Failed to set document")
   }
 }
 
-export async function updateDoc<AppModelType, DbModelType extends DocumentData>(ref: DocumentReference<AppModelType, DbModelType>, data: UpdateData<DbModelType>, converter: FirestoreDataConverter<AppModelType, DbModelType>, instance?: Transaction | WriteBatch): Promise<void> {
+export async function updateDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, data: UpdateData<DbModelType>, instance?: Transaction | WriteBatch): Promise<void> {
   try {
-    ref = ref.withConverter(converter);
     // @ts-expect-error - both Transaction & WriteBatch have a set with the same signature, but TypeScript fails to recognize that
     await (instance ? instance.update(ref, data) : ref.update(data));
   } catch (error: unknown) {
@@ -72,7 +68,7 @@ export async function updateDoc<AppModelType, DbModelType extends DocumentData>(
   }
 }
 
-export async function deleteDoc<AppModelType, DbModelType extends DocumentData>(ref: DocumentReference<AppModelType, DbModelType>, instance?: Transaction | WriteBatch): Promise<void> {
+export async function deleteDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, instance?: Transaction | WriteBatch): Promise<void> {
   try {
     await (instance ? instance.delete(ref) : ref.delete());
   } catch {
@@ -112,8 +108,8 @@ type QueryOptions<DbModelType extends DocumentData> = {
   orderBy?: OrderByClause<DbModelType>[];
 } & LimitClause & StartCursorClause & EndCursorClause;
 
-function buildQuery<AppModelType, DbModelType extends DocumentData>(collection: CollectionReference<AppModelType, DbModelType> | Collection, options?: QueryOptions<DbModelType>): Query<AppModelType, DbModelType> {
-  let queryObj: Query<AppModelType, DbModelType> = typeof collection === 'string' ? adminDb.collectionGroup(collection) as CollectionGroup<AppModelType, DbModelType> : collection;
+function buildQuery<DbModelType extends DocumentData>(collection: CollectionReference<DbModelType, DbModelType> | Collection, options?: QueryOptions<DbModelType>): Query<DbModelType, DbModelType> {
+  let queryObj: Query<DbModelType, DbModelType> = typeof collection === 'string' ? adminDb.collectionGroup(collection) as CollectionGroup<DbModelType, DbModelType> : collection;
   if (options) {
     const { where = [], orderBy = [] } = options;
     where.forEach(({ fieldPath, operation, value }) => queryObj = queryObj.where(fieldPath, operation, value));
@@ -145,10 +141,10 @@ interface ExecuteQueryOptions<DbModelType extends DocumentData> {
   queryOptions?: QueryOptions<DbModelType>;
 }
 
-export async function executeQuery<AppModelType, DbModelType extends DocumentData>(collection: CollectionReference<AppModelType, DbModelType> | Collection, converter: FirestoreDataConverter<AppModelType, DbModelType>, options?: ExecuteQueryOptions<DbModelType>): Promise<AppModelType[]> {
+export async function executeQuery<DbModelType extends DocumentData>(collection: CollectionReference<DbModelType, DbModelType> | Collection, options?: ExecuteQueryOptions<DbModelType>): Promise<DbModelType[]> {
   try {
     const { transaction, queryOptions } = options ?? {};
-    const queryObj = buildQuery(collection, queryOptions).withConverter(converter);
+    const queryObj = buildQuery(collection, queryOptions);
     const querySnapshot = await (transaction ? transaction.get(queryObj) : queryObj.get());
     return querySnapshot.docs.map(doc => doc.data());
   } catch {
@@ -167,7 +163,7 @@ interface ExecuteAggregationQueryOptions<DbModelType extends DocumentData> {
   aggregationQueryOptions: AggregationQueryOptions<DbModelType>;
 }
 
-export async function executeAggregationQuery<AppModelType, DbModelType extends DocumentData>(collection: CollectionReference<AppModelType, DbModelType> | Collection, options: ExecuteAggregationQueryOptions<DbModelType>): Promise<{ [key: string]: number | null }> {
+export async function executeAggregationQuery<DbModelType extends DocumentData>(collection: CollectionReference<DbModelType, DbModelType> | Collection, options: ExecuteAggregationQueryOptions<DbModelType>): Promise<{ [key: string]: number | null }> {
   try {
     const { transaction, aggregationQueryOptions } = options;
     const { aggregations, ...queryOptions } = aggregationQueryOptions;

--- a/functions/src/data/firestore/firestoreAdminOperations.ts
+++ b/functions/src/data/firestore/firestoreAdminOperations.ts
@@ -1,10 +1,10 @@
-import { AggregateField, AggregateType, CollectionGroup, CollectionReference, DocumentData, DocumentReference, DocumentSnapshot, GrpcStatus, PartialWithFieldValue, Query, SetOptions, Transaction, UpdateData, WhereFilterOp, WithFieldValue, WriteBatch } from "firebase-admin/firestore";
+import { AggregateField, AggregateType, CollectionGroup, CollectionReference, DocumentData, DocumentReference, DocumentSnapshot, GrpcStatus, PartialWithFieldValue, Query, QueryDocumentSnapshot, SetOptions, Transaction, UpdateData, WhereFilterOp, WithFieldValue, WriteBatch } from "firebase-admin/firestore";
 import { isFirebaseError } from "../../types/error";
 import { Collection } from "@/data/firestore/types/collections";
 import { adminDb } from "../../config/firebaseAdminConfig";
 import { DistributiveKeyof } from "@/utils/types/typeUtils";
 
-export async function getDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, transaction?: Transaction): Promise<DbModelType> {
+export async function getDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, transaction?: Transaction): Promise<DocumentSnapshot<DbModelType, DbModelType>> {
   let doc: DocumentSnapshot<DbModelType, DbModelType>;
   try {
     doc = await (transaction ? transaction.get(ref) : ref.get());
@@ -15,7 +15,7 @@ export async function getDoc<DbModelType extends DocumentData>(ref: DocumentRefe
   if (!doc.exists) {
     throw Error("Document not found");
   }
-  return doc.data()!;
+  return doc;
 }
 
 export async function createDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, data: WithFieldValue<DbModelType>, instance?: Transaction | WriteBatch): Promise<void> {
@@ -141,12 +141,12 @@ interface ExecuteQueryOptions<DbModelType extends DocumentData> {
   queryOptions?: QueryOptions<DbModelType>;
 }
 
-export async function executeQuery<DbModelType extends DocumentData>(collection: CollectionReference<DbModelType, DbModelType> | Collection, options?: ExecuteQueryOptions<DbModelType>): Promise<DbModelType[]> {
+export async function executeQuery<DbModelType extends DocumentData>(collection: CollectionReference<DbModelType, DbModelType> | Collection, options?: ExecuteQueryOptions<DbModelType>): Promise<QueryDocumentSnapshot<DbModelType, DbModelType>[]> {
   try {
     const { transaction, queryOptions } = options ?? {};
     const queryObj = buildQuery(collection, queryOptions);
     const querySnapshot = await (transaction ? transaction.get(queryObj) : queryObj.get());
-    return querySnapshot.docs.map(doc => doc.data());
+    return querySnapshot.docs;
   } catch {
     throw Error("Failed to execute query");
   }

--- a/functions/src/data/firestore/googleCredentials.ts
+++ b/functions/src/data/firestore/googleCredentials.ts
@@ -1,33 +1,33 @@
 import {
   Transaction,
   WriteBatch,
-  FirestoreDataConverter,
-  WithFieldValue,
   QueryDocumentSnapshot,
   DocumentReference,
+  DocumentSnapshot,
 } from "firebase-admin/firestore";
 import { RootLevelCollection } from "@/data/firestore/types/collections";
 import { deleteDoc, getDoc, setDoc, updateDoc } from "./firestoreAdminOperations";
 import { adminDb } from "../../config/firebaseAdminConfig";
 import { Credentials } from "google-auth-library";
 
-const googleCredentialsFirestoreConverter: FirestoreDataConverter<Credentials, Credentials> = {
-  toFirestore: (credentials: WithFieldValue<Credentials>): WithFieldValue<Credentials> => credentials,
-  fromFirestore: (snapshot: QueryDocumentSnapshot<Credentials, Credentials>): Credentials => snapshot.data()
+function fromFirestore(snapshot: DocumentSnapshot<Credentials, Credentials> | QueryDocumentSnapshot<Credentials, Credentials>): Credentials {
+  if (!snapshot.exists) { throw Error("Document not found"); };
+  return snapshot.data() as Credentials;
 }
 
 export async function getGoogleCredentialsByUid(uid: string, transaction?: Transaction): Promise<Credentials> {
-  return await getDoc<Credentials, Credentials>(adminDb.collection(RootLevelCollection.GOOGLE_OAUTH2_TOKENS).doc(uid) as DocumentReference<Credentials, Credentials>, googleCredentialsFirestoreConverter, transaction);
+  const snapshot = await getDoc<Credentials>(adminDb.collection(RootLevelCollection.GOOGLE_OAUTH2_TOKENS).doc(uid) as DocumentReference<Credentials, Credentials>, transaction);
+  return fromFirestore(snapshot);
 }
 
 export async function setGoogleCredentials(uid: string, credentials: Credentials, instance?: Transaction | WriteBatch): Promise<void> {
-  await setDoc<Credentials, Credentials>(adminDb.collection(RootLevelCollection.GOOGLE_OAUTH2_TOKENS).doc(uid) as DocumentReference<Credentials, Credentials>, credentials, googleCredentialsFirestoreConverter, { instance });
+  await setDoc<Credentials>(adminDb.collection(RootLevelCollection.GOOGLE_OAUTH2_TOKENS).doc(uid) as DocumentReference<Credentials, Credentials>, credentials, { instance });
 }
 
 export async function updateGoogleCredentials(uid: string, updates: Partial<Credentials>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<Credentials, Credentials>(adminDb.collection(RootLevelCollection.GOOGLE_OAUTH2_TOKENS).doc(uid) as DocumentReference<Credentials, Credentials>, updates, googleCredentialsFirestoreConverter, instance);
+  await updateDoc<Credentials>(adminDb.collection(RootLevelCollection.GOOGLE_OAUTH2_TOKENS).doc(uid) as DocumentReference<Credentials, Credentials>, updates, instance);
 }
 
 export async function deleteGoogleCredentials(uid: string, instance?: Transaction | WriteBatch): Promise<void> {
-  await deleteDoc<Credentials, Credentials>(adminDb.collection(RootLevelCollection.GOOGLE_OAUTH2_TOKENS).doc(uid) as DocumentReference<Credentials, Credentials>, instance);
+  await deleteDoc<Credentials>(adminDb.collection(RootLevelCollection.GOOGLE_OAUTH2_TOKENS).doc(uid) as DocumentReference<Credentials, Credentials>, instance);
 }

--- a/functions/src/data/firestore/sessions.ts
+++ b/functions/src/data/firestore/sessions.ts
@@ -4,12 +4,11 @@ import { v4 as uuid } from "uuid";
 import {
   Transaction,
   WriteBatch,
-  FirestoreDataConverter,
-  WithFieldValue,
   QueryDocumentSnapshot,
   DocumentReference,
   CollectionReference,
-  UpdateData
+  UpdateData,
+  DocumentSnapshot
 } from "firebase-admin/firestore";
 import {
   createDoc,
@@ -21,37 +20,35 @@ import {
 import { RootLevelCollection } from "@/data/firestore/types/collections";
 import { adminDb } from "../../config/firebaseAdminConfig";
 
-const sessionFirestoreConverter: FirestoreDataConverter<Session, SessionDoc> = {
-  toFirestore: (
-    session: WithFieldValue<Session>
-  ): WithFieldValue<SessionDoc> => {
-    const { id, ...dto } = session;
-    return dto;
-  },
-  fromFirestore: (
-    snapshot: QueryDocumentSnapshot<SessionDoc, SessionDoc>
-  ): Session => ({ id: snapshot.ref.id, ...snapshot.data() }),
-};
+function fromFirestore(snapshot: DocumentSnapshot<SessionDoc, SessionDoc> | QueryDocumentSnapshot<SessionDoc, SessionDoc>): Session {
+  if (!snapshot.exists) { throw Error("Document not found"); };
+  return {
+    id: snapshot.ref.id,
+    ...snapshot.data() as SessionDoc
+  };
+}
 
 export async function getSessionById(id: string, transaction?: Transaction): Promise<Session> {
-  return await getDoc<Session, SessionDoc>(adminDb.collection(RootLevelCollection.SESSIONS).doc(id) as DocumentReference<Session, SessionDoc>, sessionFirestoreConverter, transaction);
+  const snapshot = await getDoc<SessionDoc>(adminDb.collection(RootLevelCollection.SESSIONS).doc(id) as DocumentReference<SessionDoc, SessionDoc>, transaction);
+  return fromFirestore(snapshot);
 }
 
 export async function getAllSessions(): Promise<Session[]> {
-  return await executeQuery<Session, SessionDoc>(adminDb.collection(RootLevelCollection.SESSIONS) as CollectionReference<Session, SessionDoc>, sessionFirestoreConverter);
+  const snapshots = await executeQuery<SessionDoc>(adminDb.collection(RootLevelCollection.SESSIONS) as CollectionReference<SessionDoc, SessionDoc>);
+  return snapshots.map(fromFirestore);
 }
 
 export type CreateSessionDTO = SessionDoc;
 export async function setSession(session: CreateSessionDTO, instance?: Transaction | WriteBatch): Promise<string> {
   const sessionId = uuid();
-  await createDoc<Session, SessionDoc>(adminDb.collection(RootLevelCollection.SESSIONS).doc(sessionId) as DocumentReference<Session, SessionDoc>, { id: sessionId, ...session }, sessionFirestoreConverter, instance);
+  await createDoc<SessionDoc>(adminDb.collection(RootLevelCollection.SESSIONS).doc(sessionId) as DocumentReference<SessionDoc, SessionDoc>, session, instance);
   return sessionId;
 }
 
 export async function updateSession(id: string, updates: UpdateData<SessionDoc>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<Session, SessionDoc>(adminDb.collection(RootLevelCollection.SESSIONS).doc(id) as DocumentReference<Session, SessionDoc>, updates, sessionFirestoreConverter, instance);
+  await updateDoc<SessionDoc>(adminDb.collection(RootLevelCollection.SESSIONS).doc(id) as DocumentReference<SessionDoc, SessionDoc>, updates, instance);
 }
 
 export async function deleteSession(id: string, instance?: Transaction | WriteBatch): Promise<void> {
-  await deleteDoc<Session, SessionDoc>(adminDb.collection(RootLevelCollection.SESSIONS).doc(id) as DocumentReference<Session, SessionDoc>, instance);
+  await deleteDoc<SessionDoc>(adminDb.collection(RootLevelCollection.SESSIONS).doc(id) as DocumentReference<SessionDoc, SessionDoc>, instance);
 }

--- a/functions/src/data/firestore/users.ts
+++ b/functions/src/data/firestore/users.ts
@@ -4,49 +4,49 @@ import {
   Transaction,
   WriteBatch,
   QueryDocumentSnapshot,
-  FirestoreDataConverter,
-  WithFieldValue,
   DocumentReference,
   CollectionReference,
+  DocumentSnapshot,
 } from "firebase-admin/firestore";
 import { createDoc, getDoc, updateDoc, deleteDoc, executeQuery } from "./firestoreAdminOperations";
 import { RootLevelCollection } from "@/data/firestore/types/collections";
 import { adminDb } from "../../config/firebaseAdminConfig";
 
-const userFirestoreConverter: FirestoreDataConverter<User, UserDoc> = {
-  toFirestore: (user: WithFieldValue<User>) => {
-    const { id, ...dto } = user;
-    return dto;
-  },
-  fromFirestore: (snapshot: QueryDocumentSnapshot<UserDoc, UserDoc>): User => ({ id: Number(snapshot.ref.id), ...snapshot.data() })
-};
+function fromFirestore(snapshot: DocumentSnapshot<UserDoc, UserDoc> | QueryDocumentSnapshot<UserDoc, UserDoc>): User {
+  if (!snapshot.exists) { throw Error("Document not found"); };
+  return {
+    id: Number(snapshot.ref.id),
+    ...snapshot.data() as UserDoc
+  }
+}
 
 export async function getUserById(id: number, transaction?: Transaction): Promise<User> {
-  return await getDoc<User, UserDoc>(adminDb.collection(RootLevelCollection.USERS).doc(String(id)) as DocumentReference<User, UserDoc>, userFirestoreConverter, transaction);
+  const snapshot = await getDoc<UserDoc>(adminDb.collection(RootLevelCollection.USERS).doc(String(id)) as DocumentReference<UserDoc, UserDoc>, transaction);
+  return fromFirestore(snapshot);
 };
 
 export async function getUserByEmail(email: string, transaction?: Transaction): Promise<User> {
-  const users = await executeQuery<User, UserDoc>(adminDb.collection(RootLevelCollection.USERS) as CollectionReference<User, UserDoc>, userFirestoreConverter, {
+  const snapshots = await executeQuery<UserDoc>(adminDb.collection(RootLevelCollection.USERS) as CollectionReference<UserDoc, UserDoc>, {
     transaction,
     queryOptions: {
       where: [{ fieldPath: 'email', operation: '==', value: email }],
       limit: 1,
     },
   })
-  if (users.length === 0) {
+  if (snapshots.length === 0) {
     throw new Error("No user with email found");
   }
-  return users[0];
+  return fromFirestore(snapshots[0]);
 }
 
 export async function createUser(id: number, user: UserDoc, instance?: Transaction | WriteBatch): Promise<void> {
-  await createDoc<User, UserDoc>(adminDb.collection(RootLevelCollection.USERS).doc(String(id)) as DocumentReference<User, UserDoc>, { id, ...user }, userFirestoreConverter, instance);
+  await createDoc<UserDoc>(adminDb.collection(RootLevelCollection.USERS).doc(String(id)) as DocumentReference<UserDoc, UserDoc>, user, instance);
 }
 
 export async function updateUser(id: number, updates: Partial<UserDoc>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<User, UserDoc>(adminDb.collection(RootLevelCollection.USERS).doc(String(id)) as DocumentReference<User, UserDoc>, updates, userFirestoreConverter, instance);
+  await updateDoc<UserDoc>(adminDb.collection(RootLevelCollection.USERS).doc(String(id)) as DocumentReference<UserDoc, UserDoc>, updates, instance);
 }
 
 export async function deleteUser(id: number, instance?: Transaction | WriteBatch): Promise<void> {
-  await deleteDoc<User, UserDoc>(adminDb.collection(RootLevelCollection.USERS).doc(String(id)) as DocumentReference<User, UserDoc>, instance);
+  await deleteDoc<UserDoc>(adminDb.collection(RootLevelCollection.USERS).doc(String(id)) as DocumentReference<UserDoc, UserDoc>, instance);
 }

--- a/src/data/firestore/albumItemReports.ts
+++ b/src/data/firestore/albumItemReports.ts
@@ -5,70 +5,62 @@ import {
   doc, 
   collection,
   Transaction, 
-  WriteBatch, 
-  FirestoreDataConverter, 
-  WithFieldValue, 
+  WriteBatch,
   QueryDocumentSnapshot, 
   DocumentReference,
-  CollectionReference
+  CollectionReference,
+  DocumentSnapshot
 } from "firebase/firestore";
 import { getDoc, setDoc, updateDoc, deleteDoc, executeQuery } from "./firestoreClientOperations";
 import { RootLevelCollection, AlbumsSubcollection, AlbumItemsSubcollection } from "./types/collections";
 import { v4 as uuid } from "uuid";
 
-const albumItemReportFirestoreConverter: FirestoreDataConverter<AlbumItemReport, AlbumItemReportDoc> = {
-  toFirestore: (report: WithFieldValue<AlbumItemReport>): WithFieldValue<AlbumItemReportDoc> => {
-    const { id, albumItemId, albumId, ...entity } = report;
-    return entity;
-  },
-  fromFirestore: (snapshot: QueryDocumentSnapshot<AlbumItemReportDoc, AlbumItemReportDoc>): AlbumItemReport => {
-    return ({
-      id: snapshot.ref.id,
-      albumItemId: snapshot.ref.parent.parent!.id,
-      albumId: snapshot.ref.parent.parent!.parent.parent!.id,
-      ...snapshot.data()
-    });
+function fromFirestore(snapshot: DocumentSnapshot<AlbumItemReportDoc, AlbumItemReportDoc> | QueryDocumentSnapshot<AlbumItemReportDoc, AlbumItemReportDoc>): AlbumItemReport {
+  if (!snapshot.exists()) { throw Error("Document not found"); }
+  return {
+    id: snapshot.ref.id,
+    albumItemId: snapshot.ref.parent.parent!.id,
+    albumId: snapshot.ref.parent.parent!.parent.parent!.id,
+    ...snapshot.data()
   }
-};
+}
 
 export async function getAlbumItemReportDocById(albumId: string, imageId: string, reportId: string, transaction?: Transaction): Promise<AlbumItemReport> {
-  return await getDoc<AlbumItemReport, AlbumItemReportDoc>(
-    doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, imageId, AlbumItemsSubcollection.REPORTS, reportId) as DocumentReference<AlbumItemReport, AlbumItemReportDoc>, 
-    albumItemReportFirestoreConverter, 
+  const snapshot = await getDoc<AlbumItemReportDoc>(
+    doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, imageId, AlbumItemsSubcollection.REPORTS, reportId) as DocumentReference<AlbumItemReportDoc, AlbumItemReportDoc>, 
     transaction
   );
+  return fromFirestore(snapshot);
 }
 
 export async function getAlbumItemReportDocsByAlbumItemId(albumId: string, albumItemId: string): Promise<AlbumItemReport[]> {
-  return await executeQuery<AlbumItemReport, AlbumItemReportDoc>(
-    collection(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId, AlbumItemsSubcollection.REPORTS) as CollectionReference<AlbumItemReport, AlbumItemReportDoc>, 
-    albumItemReportFirestoreConverter,
+  const snapshots = await executeQuery<AlbumItemReportDoc>(
+    collection(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId, AlbumItemsSubcollection.REPORTS) as CollectionReference<AlbumItemReportDoc, AlbumItemReportDoc>, 
   );
+  return snapshots.map(fromFirestore);
 }
 
 export async function createAlbumItemReportDoc(albumId: string, albumItemId: string, report: AlbumItemReportDoc, instance?: Transaction | WriteBatch): Promise<string> {
   const reportId = uuid();
-  await setDoc<AlbumItemReport, AlbumItemReportDoc>(
-    doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId, AlbumItemsSubcollection.REPORTS, reportId) as DocumentReference<AlbumItemReport, AlbumItemReportDoc>, 
-    { id: reportId, albumItemId, albumId, ...report }, 
-    albumItemReportFirestoreConverter, 
+  await setDoc<AlbumItemReportDoc>(
+    doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId, AlbumItemsSubcollection.REPORTS, reportId) as DocumentReference<AlbumItemReportDoc, AlbumItemReportDoc>, 
+    report, 
     { instance }
   );
   return reportId;
 }
 
 export async function updateAlbumItemReportDoc(albumId: string, albumItemId: string, reportId: string, updates: Partial<AlbumItemReportDoc>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<AlbumItemReport, AlbumItemReportDoc>(
-    doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId, AlbumItemsSubcollection.REPORTS, reportId) as DocumentReference<AlbumItemReport, AlbumItemReportDoc>, 
+  await updateDoc<AlbumItemReportDoc>(
+    doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId, AlbumItemsSubcollection.REPORTS, reportId) as DocumentReference<AlbumItemReportDoc, AlbumItemReportDoc>, 
     updates, 
-    albumItemReportFirestoreConverter, 
     instance
   );
 }
 
 export async function deleteAlbumItemReportDoc(albumId: string, albumItemId: string, reportId: string, instance?: Transaction | WriteBatch): Promise<void> {
-  await deleteDoc<AlbumItemReport, AlbumItemReportDoc>(
-    doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId, AlbumItemsSubcollection.REPORTS, reportId) as DocumentReference<AlbumItemReport, AlbumItemReportDoc>, 
+  await deleteDoc<AlbumItemReportDoc>(
+    doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId, AlbumItemsSubcollection.REPORTS, reportId) as DocumentReference<AlbumItemReportDoc, AlbumItemReportDoc>, 
     instance
   );
 }

--- a/src/data/firestore/albumItems.ts
+++ b/src/data/firestore/albumItems.ts
@@ -1,30 +1,32 @@
 import { db } from "@/config/firebase";
 import { AlbumItem } from "@/types/albums/albumTypes";
 import { AlbumItemDoc } from "./types/documents";
-import { doc, Transaction, WriteBatch, FirestoreDataConverter, WithFieldValue, QueryDocumentSnapshot, DocumentReference } from "firebase/firestore";
+import { doc, Transaction, WriteBatch, QueryDocumentSnapshot, DocumentReference, DocumentSnapshot } from "firebase/firestore";
 import { getDoc, setDoc, updateDoc, deleteDoc } from "./firestoreClientOperations"
 import { AlbumsSubcollection, RootLevelCollection } from "./types/collections";
 
-const albumItemFirestoreConverter: FirestoreDataConverter<AlbumItem, AlbumItemDoc> = {
-  toFirestore: (image: WithFieldValue<AlbumItem>): WithFieldValue<AlbumItemDoc> => {
-    const { id, albumId, ...dto } = image;
-    return dto;
-  },
-  fromFirestore: (snapshot: QueryDocumentSnapshot<AlbumItemDoc, AlbumItemDoc>): AlbumItem => ({ id: snapshot.ref.id, albumId: snapshot.ref.parent.parent!.id, ...snapshot.data() })
+function fromFirestore(snapshot: DocumentSnapshot<AlbumItemDoc, AlbumItemDoc> | QueryDocumentSnapshot<AlbumItemDoc, AlbumItemDoc>): AlbumItem {
+  if (!snapshot.exists()) { throw Error("Document not found"); }
+  return {
+    id: snapshot.ref.id,
+    albumId: snapshot.ref.parent.parent!.id,
+    ...snapshot.data(),
+  }
 }
 
 export async function getAlbumItemById(albumId: string, albumItemId: string, transaction?: Transaction): Promise<AlbumItem> {
-  return await getDoc<AlbumItem, AlbumItemDoc>(doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId) as DocumentReference<AlbumItem, AlbumItemDoc>, albumItemFirestoreConverter, transaction);
+  const snapshot = await getDoc<AlbumItemDoc>(doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId) as DocumentReference<AlbumItemDoc, AlbumItemDoc>, transaction);
+  return fromFirestore(snapshot);
 }
 
-export async function createAlbumItem(albumId: string, albumItemId: string, image: AlbumItemDoc, instance?: Transaction | WriteBatch): Promise<void> {
-  await setDoc(doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId) as DocumentReference<AlbumItem, AlbumItemDoc>, { id: albumItemId, albumId, ...image }, albumItemFirestoreConverter, { instance });
+export async function createAlbumItem(albumId: string, albumItemId: string, albumItem: AlbumItemDoc, instance?: Transaction | WriteBatch): Promise<void> {
+  await setDoc(doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId) as DocumentReference<AlbumItemDoc, AlbumItemDoc>, albumItem, { instance });
 }
 
 export async function updateAlbumItem(albumId: string, albumItemId: string, updates: Partial<AlbumItemDoc>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<AlbumItem, AlbumItemDoc>(doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId) as DocumentReference<AlbumItem, AlbumItemDoc>, updates, albumItemFirestoreConverter, instance);
+  await updateDoc<AlbumItemDoc>(doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId) as DocumentReference<AlbumItemDoc, AlbumItemDoc>, updates, instance);
 }
 
 export async function deleteAlbumItem(albumId: string, albumItemId: string, instance?: Transaction | WriteBatch): Promise<void> {
-  await deleteDoc<AlbumItem, AlbumItemDoc>(doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId) as DocumentReference<AlbumItem, AlbumItemDoc>, instance);
+  await deleteDoc<AlbumItemDoc>(doc(db, RootLevelCollection.ALBUMS, albumId, AlbumsSubcollection.ALBUM_ITEMS, albumItemId) as DocumentReference<AlbumItemDoc, AlbumItemDoc>, instance);
 }

--- a/src/data/firestore/albums.ts
+++ b/src/data/firestore/albums.ts
@@ -4,34 +4,36 @@ import { AlbumDoc } from "./types/documents";
 import { v4 as uuid } from "uuid";
 import { RootLevelCollection } from "./types/collections";
 import { setDoc, deleteDoc, getDoc, updateDoc, executeQuery } from "./firestoreClientOperations";
-import { collection, CollectionReference, doc, DocumentReference, FirestoreDataConverter, QueryDocumentSnapshot, Transaction, UpdateData, WithFieldValue, WriteBatch } from "firebase/firestore";
+import { collection, CollectionReference, doc, DocumentReference, DocumentSnapshot, QueryDocumentSnapshot, Transaction, UpdateData, WriteBatch } from "firebase/firestore";
 
-const albumFirestoreConverter: FirestoreDataConverter<Album, AlbumDoc> = {
-  toFirestore: (album: WithFieldValue<Album>): WithFieldValue<AlbumDoc> => {
-    const { id, ...dto } = album;
-    return dto;
-  },
-  fromFirestore: (snapshot: QueryDocumentSnapshot<AlbumDoc, AlbumDoc>): Album => ({ id: snapshot.ref.id, ...snapshot.data() })
-};
-
-export async function getAlbumById(id: string, transaction?: Transaction): Promise<Album> {
-  return await getDoc<Album, AlbumDoc>(doc(db, RootLevelCollection.ALBUMS, id) as DocumentReference<Album, AlbumDoc>, albumFirestoreConverter, transaction);
+function fromFirestore(snapshot: DocumentSnapshot<AlbumDoc, AlbumDoc> | QueryDocumentSnapshot<AlbumDoc, AlbumDoc>): Album {
+  if (!snapshot.exists()) { throw Error("Document not found"); }
+  return {
+    id: snapshot.ref.id,
+    ...snapshot.data(),
+  }
 }
 
-export async function getAlbums() {
-  return await executeQuery<Album, AlbumDoc>(collection(db, RootLevelCollection.ALBUMS) as CollectionReference<Album, AlbumDoc>, albumFirestoreConverter);
+export async function getAlbumById(id: string, transaction?: Transaction): Promise<Album> {
+  const snapshot = await getDoc<AlbumDoc>(doc(db, RootLevelCollection.ALBUMS, id) as DocumentReference<AlbumDoc, AlbumDoc>, transaction);
+  return fromFirestore(snapshot);
+}
+
+export async function getAlbums(): Promise<Album[]> {
+  const snapshots = await executeQuery<AlbumDoc>(collection(db, RootLevelCollection.ALBUMS) as CollectionReference<AlbumDoc, AlbumDoc>);
+  return snapshots.map(fromFirestore);
 }
 
 export async function createAlbum(album: AlbumDoc, instance?: Transaction | WriteBatch): Promise<string> {
   const albumId = uuid();
-  await setDoc<Album, AlbumDoc>(doc(db, RootLevelCollection.ALBUMS, albumId) as DocumentReference<Album, AlbumDoc>, { id: albumId, ...album }, albumFirestoreConverter, { instance });
+  await setDoc<AlbumDoc>(doc(db, RootLevelCollection.ALBUMS, albumId) as DocumentReference<AlbumDoc, AlbumDoc>, album, { instance });
   return albumId;
 }
 
 export async function updateAlbum(id: string, updates: UpdateData<AlbumDoc>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<Album, AlbumDoc>(doc(db, RootLevelCollection.ALBUMS, id) as DocumentReference<Album, AlbumDoc>, updates, albumFirestoreConverter, instance);
+  await updateDoc<AlbumDoc>(doc(db, RootLevelCollection.ALBUMS, id) as DocumentReference<AlbumDoc, AlbumDoc>, updates, instance);
 }
 
 export async function deleteAlbum(id: string, instance?: Transaction | WriteBatch): Promise<void> {
-  await deleteDoc<Album, AlbumDoc>(doc(db, RootLevelCollection.ALBUMS, id) as DocumentReference<Album, AlbumDoc>, instance);
+  await deleteDoc<AlbumDoc>(doc(db, RootLevelCollection.ALBUMS, id) as DocumentReference<AlbumDoc, AlbumDoc>, instance);
 }

--- a/src/data/firestore/attendees.ts
+++ b/src/data/firestore/attendees.ts
@@ -6,37 +6,39 @@ import {
   Transaction,
   WriteBatch,
   QueryDocumentSnapshot,
-  FirestoreDataConverter,
-  WithFieldValue,
   DocumentReference,
   collection,
-  CollectionReference
+  CollectionReference,
+  DocumentSnapshot
 } from "firebase/firestore";
 import { setDoc, getDoc, updateDoc, executeQuery } from "./firestoreClientOperations";
 import { RootLevelCollection, SessionsSubcollection } from "./types/collections";
 
-const attendeeFirestoreConverter: FirestoreDataConverter<Attendee, AttendeeDoc> = {
-  toFirestore: (attendee: WithFieldValue<Attendee>) => {
-    const { attendeeId, sessionId, ...dto } = attendee;
-    return dto as WithFieldValue<Attendee>;
-  },
-  fromFirestore: (snapshot: QueryDocumentSnapshot<AttendeeDoc, AttendeeDoc>): Attendee => ({ attendeeId: Number(snapshot.ref.id), sessionId: snapshot.ref.parent.parent!.id, ...snapshot.data(), })
-};
+function fromFirestore(snapshot: DocumentSnapshot<AttendeeDoc, AttendeeDoc> | QueryDocumentSnapshot<AttendeeDoc, AttendeeDoc>): Attendee {
+  if (!snapshot.exists()) { throw Error("Document not found"); }
+  return {
+    attendeeId: Number(snapshot.ref.id),
+    sessionId: snapshot.ref.parent.parent!.id,
+    ...snapshot.data()
+  };
+}
 
 export async function getAttendeeById(campminderId: number, sessionId: string, transaction?: Transaction): Promise<Attendee> {
-  return await getDoc<Attendee, AttendeeDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.ATTENDEES, String(campminderId)) as DocumentReference<Attendee, AttendeeDoc>, attendeeFirestoreConverter, transaction);
+  const snapshot = await getDoc<AttendeeDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.ATTENDEES, String(campminderId)) as DocumentReference<AttendeeDoc, AttendeeDoc>, transaction);
+  return fromFirestore(snapshot);
 };
 
 export async function getAttendeesBySessionId(sessionId: string): Promise<Attendee[]> {
-  return await executeQuery<Attendee, AttendeeDoc>(collection(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.ATTENDEES) as CollectionReference<Attendee, AttendeeDoc>, attendeeFirestoreConverter);
+  const snapshots = await executeQuery<AttendeeDoc>(collection(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.ATTENDEES) as CollectionReference<AttendeeDoc, AttendeeDoc>);
+  return snapshots.map(fromFirestore);
 }
 
 export async function createAttendee(campminderId: number, sessionId: string, attendee: AttendeeDoc, instance?: Transaction | WriteBatch): Promise<number> {
   const attendeeId = campminderId;
-  await setDoc<Attendee, AttendeeDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.ATTENDEES, String(campminderId)) as DocumentReference<Attendee, AttendeeDoc>, { attendeeId, sessionId: sessionId, ...attendee }, attendeeFirestoreConverter, { instance });
+  await setDoc<AttendeeDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.ATTENDEES, String(campminderId)) as DocumentReference<AttendeeDoc, AttendeeDoc>, attendee, { instance });
   return attendeeId;
 }
 
 export async function updateAttendee(campminderId: number, sessionId: string, updates: Partial<AttendeeDoc>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<Attendee, AttendeeDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.ATTENDEES, String(campminderId)) as DocumentReference<Attendee, AttendeeDoc>, updates, attendeeFirestoreConverter, instance);
+  await updateDoc<AttendeeDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.ATTENDEES, String(campminderId)) as DocumentReference<AttendeeDoc, AttendeeDoc>, updates, instance);
 }

--- a/src/data/firestore/firestoreClientOperations.ts
+++ b/src/data/firestore/firestoreClientOperations.ts
@@ -1,10 +1,10 @@
 import { FirebaseError } from "firebase/app";
-import { DocumentReference, Query, Transaction, WriteBatch, DocumentSnapshot, getDoc as getFirestore, setDoc as setFirestore, updateDoc as updateFirestore, deleteDoc as deleteFirestore, getDocs as queryFirestore, WithFieldValue, DocumentData, UpdateData, CollectionReference, WhereFilterOp, collectionGroup, where as whereFirestore, orderBy as orderByFirestore, limit, limitToLast, startAfter, startAt, endBefore, endAt, query, documentId, getAggregateFromServer, AggregateType, count, AggregateField, sum, average, SetOptions, PartialWithFieldValue } from "firebase/firestore";
+import { DocumentReference, Query, Transaction, WriteBatch, DocumentSnapshot, getDoc as getFirestore, setDoc as setFirestore, updateDoc as updateFirestore, deleteDoc as deleteFirestore, getDocs as queryFirestore, WithFieldValue, DocumentData, UpdateData, CollectionReference, WhereFilterOp, collectionGroup, where as whereFirestore, orderBy as orderByFirestore, limit, limitToLast, startAfter, startAt, endBefore, endAt, query, documentId, getAggregateFromServer, AggregateType, count, AggregateField, sum, average, SetOptions, PartialWithFieldValue, QueryDocumentSnapshot } from "firebase/firestore";
 import { db } from "@/config/firebase";
 import { Collection } from "./types/collections";
 import { DistributiveKeyof } from "@/utils/types/typeUtils";
 
-export async function getDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, transaction?: Transaction): Promise<DbModelType> {
+export async function getDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, transaction?: Transaction): Promise<DocumentSnapshot<DbModelType, DbModelType>> {
   let doc: DocumentSnapshot<DbModelType, DbModelType>;
   try {
     doc = await (transaction ? transaction.get(ref) : getFirestore(ref));
@@ -15,7 +15,7 @@ export async function getDoc<DbModelType extends DocumentData>(ref: DocumentRefe
   if (!doc.exists()) {
     throw Error("Document not found");
   }
-  return doc.data();
+  return doc;
 }
 
 export async function assertDocumentDoesNotExist(ref: DocumentReference, instance?: Transaction): Promise<void> {
@@ -135,11 +135,11 @@ function buildQuery<DbModelType extends DocumentData>(collection: CollectionRefe
   return queryObj;
 }
 
-export async function executeQuery<DbModelType extends DocumentData>(collection: CollectionReference<DbModelType, DbModelType> | Collection, options?: QueryOptions<DbModelType>): Promise<DbModelType[]> {
+export async function executeQuery<DbModelType extends DocumentData>(collection: CollectionReference<DbModelType, DbModelType> | Collection, options?: QueryOptions<DbModelType>): Promise<QueryDocumentSnapshot<DbModelType, DbModelType>[]> {
   try {
     const queryObj = buildQuery(collection, options);
     const querySnapshot = await queryFirestore(queryObj);
-    return querySnapshot.docs.map(doc => doc.data());
+    return querySnapshot.docs;
   } catch {
     throw Error("Failed to execute query");
   }

--- a/src/data/firestore/firestoreClientOperations.ts
+++ b/src/data/firestore/firestoreClientOperations.ts
@@ -1,13 +1,12 @@
 import { FirebaseError } from "firebase/app";
-import { DocumentReference, Query, Transaction, WriteBatch, DocumentSnapshot, getDoc as getFirestore, setDoc as setFirestore, updateDoc as updateFirestore, deleteDoc as deleteFirestore, getDocs as queryFirestore, WithFieldValue, DocumentData, UpdateData, FirestoreDataConverter, CollectionReference, WhereFilterOp, collectionGroup, where as whereFirestore, orderBy as orderByFirestore, limit, limitToLast, startAfter, startAt, endBefore, endAt, query, documentId, getAggregateFromServer, AggregateType, count, AggregateField, sum, average, SetOptions, PartialWithFieldValue } from "firebase/firestore";
+import { DocumentReference, Query, Transaction, WriteBatch, DocumentSnapshot, getDoc as getFirestore, setDoc as setFirestore, updateDoc as updateFirestore, deleteDoc as deleteFirestore, getDocs as queryFirestore, WithFieldValue, DocumentData, UpdateData, CollectionReference, WhereFilterOp, collectionGroup, where as whereFirestore, orderBy as orderByFirestore, limit, limitToLast, startAfter, startAt, endBefore, endAt, query, documentId, getAggregateFromServer, AggregateType, count, AggregateField, sum, average, SetOptions, PartialWithFieldValue } from "firebase/firestore";
 import { db } from "@/config/firebase";
 import { Collection } from "./types/collections";
 import { DistributiveKeyof } from "@/utils/types/typeUtils";
 
-export async function getDoc<AppModelType, DbModelType extends DocumentData>(ref: DocumentReference<AppModelType, DbModelType>, converter: FirestoreDataConverter<AppModelType, DbModelType>, transaction?: Transaction): Promise<AppModelType> {
-  let doc: DocumentSnapshot<AppModelType, DbModelType>;
+export async function getDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, transaction?: Transaction): Promise<DbModelType> {
+  let doc: DocumentSnapshot<DbModelType, DbModelType>;
   try {
-    ref = ref.withConverter(converter);
     doc = await (transaction ? transaction.get(ref) : getFirestore(ref));
   } catch {
     throw Error("Error getting document");
@@ -35,11 +34,10 @@ interface SetDocOverwriteOptions {
   instance?: Transaction | WriteBatch;
 };
 
-export async function setDoc<AppModelType, DbModelType extends DocumentData>(ref: DocumentReference<AppModelType, DbModelType>, data: WithFieldValue<AppModelType>, converter: FirestoreDataConverter<AppModelType, DbModelType>, options?: SetDocOverwriteOptions): Promise<void>
-export async function setDoc<AppModelType, DbModelType extends DocumentData>(ref: DocumentReference<AppModelType, DbModelType>, data: PartialWithFieldValue<AppModelType>, converter: FirestoreDataConverter<AppModelType, DbModelType>, options: SetDocMergeOptions): Promise<void>
-export async function setDoc<AppModelType, DbModelType extends DocumentData>(ref: DocumentReference<AppModelType, DbModelType>, data: WithFieldValue<AppModelType> | PartialWithFieldValue<AppModelType>, converter: FirestoreDataConverter<AppModelType, DbModelType>, options?: SetDocOptions): Promise<void> {
+export async function setDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, data: WithFieldValue<DbModelType>, options?: SetDocOverwriteOptions): Promise<void>
+export async function setDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, data: PartialWithFieldValue<DbModelType>, options: SetDocMergeOptions): Promise<void>
+export async function setDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, data: WithFieldValue<DbModelType> | PartialWithFieldValue<DbModelType>, options?: SetDocOptions): Promise<void> {
   try {
-    ref = ref.withConverter(converter);
     options = options ?? {};
     const { instance } = options;
     if ('mergeOptions' in options) {
@@ -54,9 +52,8 @@ export async function setDoc<AppModelType, DbModelType extends DocumentData>(ref
   }
 }
 
-export async function updateDoc<AppModelType, DbModelType extends DocumentData>(ref: DocumentReference<AppModelType, DbModelType>, data: UpdateData<AppModelType>, converter: FirestoreDataConverter<AppModelType, DbModelType>, instance?: Transaction | WriteBatch): Promise<void> {
+export async function updateDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, data: UpdateData<DbModelType>, instance?: Transaction | WriteBatch): Promise<void> {
   try {
-    ref = ref.withConverter(converter);
     // @ts-expect-error - both Transaction & WriteBatch have a set with the same signature, but TypeScript fails to recognize that
     await (instance ? instance.update(ref, data) : updateFirestore(ref, data));
   } catch (error) {
@@ -67,7 +64,7 @@ export async function updateDoc<AppModelType, DbModelType extends DocumentData>(
   }
 }
 
-export async function deleteDoc<AppModelType, DbModelType extends DocumentData>(ref: DocumentReference<AppModelType, DbModelType>, instance?: Transaction | WriteBatch): Promise<void> {
+export async function deleteDoc<DbModelType extends DocumentData>(ref: DocumentReference<DbModelType, DbModelType>, instance?: Transaction | WriteBatch): Promise<void> {
   try {
     await (instance ? instance.delete(ref) : deleteFirestore(ref));
   } catch {
@@ -107,8 +104,8 @@ type QueryOptions<DbModelType extends DocumentData> = {
   orderBy?: OrderByClause<DbModelType>[];
 } & LimitClause & StartCursorClause & EndCursorClause;
 
-function buildQuery<AppModelType, DbModelType extends DocumentData>(collection: CollectionReference<AppModelType, DbModelType> | Collection, options?: QueryOptions<DbModelType>): Query<AppModelType, DbModelType> {
-  let queryObj: Query<AppModelType, DbModelType> = typeof collection === 'string' ? collectionGroup(db, collection) as Query<AppModelType, DbModelType> : collection;
+function buildQuery<DbModelType extends DocumentData>(collection: CollectionReference<DbModelType, DbModelType> | Collection, options?: QueryOptions<DbModelType>): Query<DbModelType, DbModelType> {
+  let queryObj: Query<DbModelType, DbModelType> = typeof collection === 'string' ? collectionGroup(db, collection) as Query<DbModelType, DbModelType> : collection;
   if (options) {
     const { where = [], orderBy = [] } = options;
     const whereClauses = where.map(({ fieldPath, operation, value }) => whereFirestore(fieldPath === '__name__' ? documentId() : fieldPath, operation, value));
@@ -138,9 +135,9 @@ function buildQuery<AppModelType, DbModelType extends DocumentData>(collection: 
   return queryObj;
 }
 
-export async function executeQuery<AppModelType, DbModelType extends DocumentData>(collection: CollectionReference<AppModelType, DbModelType> | Collection, converter: FirestoreDataConverter<AppModelType, DbModelType>, options?: QueryOptions<DbModelType>): Promise<AppModelType[]> {
+export async function executeQuery<DbModelType extends DocumentData>(collection: CollectionReference<DbModelType, DbModelType> | Collection, options?: QueryOptions<DbModelType>): Promise<DbModelType[]> {
   try {
-    const queryObj = buildQuery(collection, options).withConverter(converter);
+    const queryObj = buildQuery(collection, options);
     const querySnapshot = await queryFirestore(queryObj);
     return querySnapshot.docs.map(doc => doc.data());
   } catch {
@@ -154,7 +151,7 @@ type AggregationClause<DbModelType> = { aggregateFieldName: string; } & (
 
 type AggregationQueryOptions<DbModelType extends DocumentData> = QueryOptions<DbModelType> & { aggregations: AggregationClause<DbModelType>[]; }
 
-export async function executeAggregationQuery<AppModelType, DbModelType extends DocumentData>(collection: CollectionReference<AppModelType, DbModelType> | Collection, options: AggregationQueryOptions<DbModelType>): Promise<{ [key: string]: number | null }> {
+export async function executeAggregationQuery<DbModelType extends DocumentData>(collection: CollectionReference<DbModelType, DbModelType> | Collection, options: AggregationQueryOptions<DbModelType>): Promise<{ [key: string]: number | null }> {
   try {
     const { aggregations, ...queryOptions } = options;
     const queryObj = buildQuery(collection, queryOptions);

--- a/src/data/firestore/freeplays.ts
+++ b/src/data/firestore/freeplays.ts
@@ -1,30 +1,32 @@
 import { db } from "@/config/firebase";
 import { Freeplay } from "@/types/sessions/sessionTypes";
 import { FreeplayDoc } from "./types/documents";
-import { doc, Transaction, WriteBatch, QueryDocumentSnapshot, FirestoreDataConverter, WithFieldValue, DocumentReference } from "firebase/firestore";
+import { doc, Transaction, WriteBatch, QueryDocumentSnapshot, DocumentReference, DocumentSnapshot } from "firebase/firestore";
 import { setDoc, deleteDoc, getDoc, updateDoc } from "./firestoreClientOperations";
 import { RootLevelCollection, SessionsSubcollection } from "./types/collections";
 
-const freeplayFirestoreConverter: FirestoreDataConverter<Freeplay, FreeplayDoc> = {
-  toFirestore: (freeplay: WithFieldValue<Freeplay>): WithFieldValue<FreeplayDoc> => {
-    const { date, sessionId, ...dto } = freeplay;
-    return dto;
-  },
-  fromFirestore: (snapshot: QueryDocumentSnapshot<FreeplayDoc, FreeplayDoc>): Freeplay => ({ date: snapshot.ref.id, sessionId: snapshot.ref.parent.parent!.id, ...snapshot.data() })
-};
+function fromFirestore(snapshot: DocumentSnapshot<FreeplayDoc, FreeplayDoc> | QueryDocumentSnapshot<FreeplayDoc, FreeplayDoc>): Freeplay {
+  if (!snapshot.exists()) { throw Error("Document not found"); }
+  return {
+    date: snapshot.ref.id,
+    sessionId: snapshot.ref.parent.parent!.id,
+    ...snapshot.data()
+  };
+}
 
 export async function getFreeplayById(sessionId: string, freeplayId: string, transaction?: Transaction): Promise<Freeplay> {
-  return await getDoc<Freeplay, FreeplayDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.FREEPLAYS, freeplayId) as DocumentReference<Freeplay, FreeplayDoc>, freeplayFirestoreConverter, transaction);
+  const snapshot = await getDoc<FreeplayDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.FREEPLAYS, freeplayId) as DocumentReference<FreeplayDoc, FreeplayDoc>, transaction);
+  return fromFirestore(snapshot);
 };
 
 export async function createFreeplay(sessionId: string, freeplay: Freeplay, instance?: Transaction | WriteBatch): Promise<void> {
-  await setDoc<Freeplay, FreeplayDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.FREEPLAYS, freeplay.date) as DocumentReference<Freeplay, FreeplayDoc>, freeplay, freeplayFirestoreConverter, { instance });
+  await setDoc<FreeplayDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.FREEPLAYS, freeplay.date) as DocumentReference<FreeplayDoc, FreeplayDoc>, freeplay, { instance });
 };
 
 export async function updateFreeplay(sessionId: string, freeplayId: string, updates: Partial<FreeplayDoc>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<Freeplay, FreeplayDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.FREEPLAYS, freeplayId) as DocumentReference<Freeplay, FreeplayDoc>, updates, freeplayFirestoreConverter, instance);
+  await updateDoc<FreeplayDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.FREEPLAYS, freeplayId) as DocumentReference<FreeplayDoc, FreeplayDoc>, updates, instance);
 };
 
 export async function deleteFreeplay(sessionId: string, freeplayId: string, instance?: Transaction | WriteBatch): Promise<void> {
-  await deleteDoc<Freeplay, FreeplayDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.FREEPLAYS, freeplayId) as DocumentReference<Freeplay, FreeplayDoc>, instance);
+  await deleteDoc<FreeplayDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.FREEPLAYS, freeplayId) as DocumentReference<FreeplayDoc, FreeplayDoc>, instance);
 };

--- a/src/data/firestore/nightSchedules.ts
+++ b/src/data/firestore/nightSchedules.ts
@@ -6,40 +6,42 @@ import {
   Transaction,
   WriteBatch,
   QueryDocumentSnapshot,
-  FirestoreDataConverter,
-  WithFieldValue,
   DocumentReference,
   collection,
   CollectionReference,
-  UpdateData
+  UpdateData,
+  DocumentSnapshot
 } from "firebase/firestore";
 import { setDoc, getDoc, updateDoc, executeQuery, deleteDoc } from "./firestoreClientOperations";
 import { RootLevelCollection, SessionsSubcollection } from "./types/collections";
 
-const nightScheduleFirestoreConverter: FirestoreDataConverter<NightSchedule, NightScheduleDoc> = {
-  toFirestore: (nightShift: WithFieldValue<NightSchedule>) => {
-    const { date, sessionId, ...dto } = nightShift;
-    return dto as WithFieldValue<NightSchedule>;
-  },
-  fromFirestore: (snapshot: QueryDocumentSnapshot<NightScheduleDoc, NightScheduleDoc>): NightSchedule => ({ date: snapshot.ref.id, sessionId: snapshot.ref.parent.parent!.id, ...snapshot.data() })
-};
+function fromFirestore(snapshot: DocumentSnapshot<NightScheduleDoc, NightScheduleDoc> | QueryDocumentSnapshot<NightScheduleDoc, NightScheduleDoc>): NightSchedule {
+  if (!snapshot.exists()) { throw Error("Document not found"); }
+  return {
+    date: snapshot.ref.id,
+    sessionId: snapshot.ref.parent.parent!.id,
+    ...snapshot.data()
+  }
+}
 
 export async function getNightScheduleById(id: string, sessionId: string, transaction?: Transaction): Promise<NightSchedule> {
-  return await getDoc<NightSchedule, NightScheduleDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.NIGHT_SCHEDULES, id) as DocumentReference<NightSchedule, NightScheduleDoc>, nightScheduleFirestoreConverter, transaction);
+  const snapshot = await getDoc<NightScheduleDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.NIGHT_SCHEDULES, id) as DocumentReference<NightScheduleDoc, NightScheduleDoc>, transaction);
+  return fromFirestore(snapshot);
 };
 
 export async function getNightSchedulesBySessionId(sessionId: string): Promise<NightSchedule[]> {
-  return await executeQuery<NightSchedule, NightScheduleDoc>(collection(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.NIGHT_SCHEDULES) as CollectionReference<NightSchedule, NightScheduleDoc>, nightScheduleFirestoreConverter);
+  const snapshots = await executeQuery<NightScheduleDoc>(collection(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.NIGHT_SCHEDULES) as CollectionReference<NightScheduleDoc, NightScheduleDoc>);
+  return snapshots.map(fromFirestore);
 }
 
 export async function createNightSchedule(date: string, sessionId: string, nightShift: NightScheduleDoc, instance?: Transaction | WriteBatch): Promise<void> {
-  await setDoc<NightSchedule, NightScheduleDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.NIGHT_SCHEDULES, date) as DocumentReference<NightSchedule, NightScheduleDoc>, { date, sessionId, ...nightShift }, nightScheduleFirestoreConverter, { instance });
+  await setDoc<NightScheduleDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.NIGHT_SCHEDULES, date) as DocumentReference<NightScheduleDoc, NightScheduleDoc>, nightShift, { instance });
 }
 
 export async function updateNightSchedule(id: string, sessionId: string, updates: UpdateData<NightScheduleDoc>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<NightSchedule, NightScheduleDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.NIGHT_SCHEDULES, id) as DocumentReference<NightSchedule, NightScheduleDoc>, updates, nightScheduleFirestoreConverter, instance);
+  await updateDoc<NightScheduleDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.NIGHT_SCHEDULES, id) as DocumentReference<NightScheduleDoc, NightScheduleDoc>, updates, instance);
 }
 
 export async function deleteNightSchedule(id: string, sessionId: string, instance?: Transaction | WriteBatch): Promise<void> {
-  await deleteDoc<NightSchedule, NightScheduleDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.NIGHT_SCHEDULES, id) as DocumentReference<NightSchedule, NightScheduleDoc>, instance);
+  await deleteDoc<NightScheduleDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.NIGHT_SCHEDULES, id) as DocumentReference<NightScheduleDoc, NightScheduleDoc>, instance);
 }

--- a/src/data/firestore/programAreas.ts
+++ b/src/data/firestore/programAreas.ts
@@ -6,26 +6,26 @@ import {
   Transaction,
   WriteBatch,
   QueryDocumentSnapshot,
-  FirestoreDataConverter,
-  WithFieldValue,
   DocumentReference,
   collection,
   UpdateData,
-  CollectionReference
+  CollectionReference,
+  DocumentSnapshot
 } from "firebase/firestore";
 import { setDoc, getDoc, updateDoc, executeQuery, deleteDoc } from "./firestoreClientOperations";
 import { RootLevelCollection } from "./types/collections";
 
-const programAreaFirestoreConverter: FirestoreDataConverter<ProgramArea, ProgramAreaDoc> = {
-  toFirestore: (programArea: WithFieldValue<ProgramArea>) => {
-    const { id, ...dto } = programArea;
-    return dto as WithFieldValue<ProgramArea>;
-  },
-  fromFirestore: (snapshot: QueryDocumentSnapshot<ProgramAreaDoc, ProgramAreaDoc>): ProgramArea => ({ id: snapshot.ref.id, ...snapshot.data() })
-};
+function fromFirestore(snapshot: DocumentSnapshot<ProgramAreaDoc, ProgramAreaDoc> | QueryDocumentSnapshot<ProgramAreaDoc, ProgramAreaDoc>): ProgramArea {
+  if (!snapshot.exists()) { throw Error("Document not found"); }
+  return {
+    id: snapshot.ref.id,
+    ...snapshot.data()
+  }
+}
 
 export async function getProgramAreaById(id: string, transaction?: Transaction): Promise<ProgramArea> {
-  return await getDoc<ProgramArea, ProgramAreaDoc>(doc(db, RootLevelCollection.PROGRAM_AREAS, id) as DocumentReference<ProgramArea, ProgramAreaDoc>, programAreaFirestoreConverter, transaction);
+  const snapshot = await getDoc<ProgramAreaDoc>(doc(db, RootLevelCollection.PROGRAM_AREAS, id) as DocumentReference<ProgramAreaDoc, ProgramAreaDoc>, transaction);
+  return fromFirestore(snapshot);
 };
 
 export async function getProgramAreasByIds(ids: string[]): Promise<ProgramArea[]> {
@@ -33,22 +33,21 @@ export async function getProgramAreasByIds(ids: string[]): Promise<ProgramArea[]
   for (let i = 0; i < ids.length; i += 30) {
     idBatches.push(ids.slice(i, i + 30));
   }
-  const responses = await Promise.all(idBatches.flatMap(idBatch => executeQuery<ProgramArea, ProgramAreaDoc>(
-    collection(db, RootLevelCollection.PROGRAM_AREAS) as CollectionReference<ProgramArea, ProgramAreaDoc>,
-    programAreaFirestoreConverter,
+  const responses = await Promise.all(idBatches.flatMap(idBatch => executeQuery<ProgramAreaDoc>(
+    collection(db, RootLevelCollection.PROGRAM_AREAS) as CollectionReference<ProgramAreaDoc, ProgramAreaDoc>,
     { where: [{ fieldPath: '__name__', operation: 'in', value: idBatch }] }
   )));
-  return responses.flatMap(response => response)
+  return responses.flatMap(response => response).map(fromFirestore);
 }
 
 export async function createProgramArea(id: string, programArea: ProgramAreaDoc, instance?: Transaction | WriteBatch): Promise<void> {
-  await setDoc<ProgramArea, ProgramAreaDoc>(doc(db, RootLevelCollection.PROGRAM_AREAS, id) as DocumentReference<ProgramArea, ProgramAreaDoc>, { id, ...programArea }, programAreaFirestoreConverter, { instance });
+  await setDoc<ProgramAreaDoc>(doc(db, RootLevelCollection.PROGRAM_AREAS, id) as DocumentReference<ProgramAreaDoc, ProgramAreaDoc>, programArea, { instance });
 }
 
 export async function updateProgramArea(id: string, updates: UpdateData<ProgramAreaDoc>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<ProgramArea, ProgramAreaDoc>(doc(db, RootLevelCollection.PROGRAM_AREAS, id) as DocumentReference<ProgramArea, ProgramAreaDoc>, updates, programAreaFirestoreConverter, instance);
+  await updateDoc<ProgramAreaDoc>(doc(db, RootLevelCollection.PROGRAM_AREAS, id) as DocumentReference<ProgramAreaDoc, ProgramAreaDoc>, updates, instance);
 }
 
 export async function deleteProgramArea(id: string, instance?: Transaction | WriteBatch): Promise<void> {
-  await deleteDoc<ProgramArea, ProgramAreaDoc>(doc(db, RootLevelCollection.PROGRAM_AREAS, id) as DocumentReference<ProgramArea, ProgramAreaDoc>, instance);
+  await deleteDoc<ProgramAreaDoc>(doc(db, RootLevelCollection.PROGRAM_AREAS, id) as DocumentReference<ProgramAreaDoc, ProgramAreaDoc>, instance);
 }

--- a/src/data/firestore/sectionSchedules.ts
+++ b/src/data/firestore/sectionSchedules.ts
@@ -1,18 +1,20 @@
 import { SectionSchedule } from "@/types/scheduling/schedulingTypes";
 import { SectionScheduleDoc } from "./types/documents";
-import { doc, DocumentReference, FirestoreDataConverter, QueryDocumentSnapshot, Transaction, WithFieldValue } from "firebase/firestore";
+import { doc, DocumentReference, DocumentSnapshot, QueryDocumentSnapshot, Transaction } from "firebase/firestore";
 import { getDoc } from "./firestoreClientOperations";
 import { db } from "@/config/firebase";
 import { RootLevelCollection, SectionsSubcollection, SessionsSubcollection } from "./types/collections";
 
-const sectionScheduleFirestoreConverter: FirestoreDataConverter<SectionSchedule, SectionScheduleDoc> = {
-  toFirestore: (schedule: WithFieldValue<SectionSchedule>): WithFieldValue<SectionScheduleDoc> => {
-    const { sectionId, sessionId, ...dto } = schedule;
-    return dto;
-  },
-  fromFirestore: (snapshot: QueryDocumentSnapshot<SectionScheduleDoc, SectionScheduleDoc>): SectionSchedule => ({ sectionId: snapshot.ref.parent.parent!.id, sessionId: snapshot.ref.parent.parent!.parent.parent!.id, ...snapshot.data() })
+function fromFirestore(snapshot: DocumentSnapshot<SectionScheduleDoc, SectionScheduleDoc> | QueryDocumentSnapshot<SectionScheduleDoc, SectionScheduleDoc>): SectionSchedule {
+  if (!snapshot.exists()) { throw Error("Document not found"); };
+  return {
+    sectionId: snapshot.ref.parent.parent!.id,
+    sessionId: snapshot.ref.parent.parent!.parent.parent!.id,
+    ...snapshot.data()
+  }
 }
 
 export async function getSectionSchedule(sessionId: string, sectionId: string, transaction?: Transaction): Promise<SectionSchedule> {
-  return await getDoc<SectionSchedule, SectionScheduleDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.SECTIONS, sectionId, SectionsSubcollection.SCHEDULE, SectionsSubcollection.SCHEDULE) as DocumentReference<SectionSchedule, SectionScheduleDoc>, sectionScheduleFirestoreConverter, transaction);
-} 
+  const snapshot = await getDoc<SectionScheduleDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.SECTIONS, sectionId, SectionsSubcollection.SCHEDULE, SectionsSubcollection.SCHEDULE) as DocumentReference<SectionScheduleDoc, SectionScheduleDoc>, transaction);
+  return fromFirestore(snapshot);
+}

--- a/src/data/firestore/sections.ts
+++ b/src/data/firestore/sections.ts
@@ -7,42 +7,44 @@ import {
   collection,
   Transaction,
   WriteBatch,
-  FirestoreDataConverter,
-  WithFieldValue,
   QueryDocumentSnapshot,
   DocumentReference,
   CollectionReference,
   UpdateData,
+  DocumentSnapshot,
 } from "firebase/firestore";
 import { RootLevelCollection, SessionsSubcollection } from "./types/collections";
 import { setDoc, deleteDoc, getDoc, updateDoc, executeQuery } from "./firestoreClientOperations";
 
-const sectionFirestoreConverter: FirestoreDataConverter<Section, SectionDoc> = {
-  toFirestore: (section: WithFieldValue<Section>): WithFieldValue<SectionDoc> => {
-    const { id, sessionId, ...dto } = section;
-    return dto;
-  },
-  fromFirestore: (snapshot: QueryDocumentSnapshot<SectionDoc, SectionDoc>): Section => ({ id: snapshot.ref.id, sessionId: snapshot.ref.parent.parent!.id, ...snapshot.data() })
+function fromFirestore(snapshot: DocumentSnapshot<SectionDoc, SectionDoc> | QueryDocumentSnapshot<SectionDoc, SectionDoc>): Section {
+  if (!snapshot.exists()) { throw Error("Document not found"); };
+  return {
+    id: snapshot.ref.id,
+    sessionId: snapshot.ref.parent.parent!.id,
+    ...snapshot.data()
+  }
 }
 
 export async function getSectionById(sessionId: string, sectionId: string, transaction?: Transaction): Promise<Section> {
-  return await getDoc<Section, SectionDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.SECTIONS, sectionId) as DocumentReference<Section, SectionDoc>, sectionFirestoreConverter, transaction);
+  const snapshot = await getDoc<SectionDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.SECTIONS, sectionId) as DocumentReference<SectionDoc, SectionDoc>, transaction);
+  return fromFirestore(snapshot);
 }
 
 export async function getSectionsBySessionId(sessionId: string): Promise<Section[]> {
-  return await executeQuery<Section, SectionDoc>(collection(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.SECTIONS) as CollectionReference<Section, SectionDoc>, sectionFirestoreConverter);
+  const snapshots = await executeQuery<SectionDoc>(collection(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.SECTIONS) as CollectionReference<SectionDoc, SectionDoc>);
+  return snapshots.map(fromFirestore);
 }
 
 export async function createSection(sessionId: string, section: SectionDoc, instance?: Transaction | WriteBatch): Promise<string> {
   const sectionId = uuid();
-  await setDoc<Section, SectionDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.SECTIONS, sectionId) as DocumentReference<Section, SectionDoc>, { id: sectionId, sessionId, ...section }, sectionFirestoreConverter, { instance });
+  await setDoc<SectionDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.SECTIONS, sectionId) as DocumentReference<SectionDoc, SectionDoc>, section, { instance });
   return sectionId;
 }
 
 export async function updateSection(sessionId: string, sectionId: string, updates: UpdateData<SectionDoc>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<Section, SectionDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.SECTIONS, sectionId) as DocumentReference<Section, SectionDoc>, updates, sectionFirestoreConverter, instance);
+  await updateDoc<SectionDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.SECTIONS, sectionId) as DocumentReference<SectionDoc, SectionDoc>, updates, instance);
 }
 
 export async function deleteSection(id: string, sessionID: string, instance?: Transaction | WriteBatch): Promise<void> {
-  await deleteDoc<Section, SectionDoc>(doc(db, RootLevelCollection.SESSIONS, sessionID, SessionsSubcollection.SECTIONS, id) as DocumentReference<Section, SectionDoc>, instance);
+  await deleteDoc<SectionDoc>(doc(db, RootLevelCollection.SESSIONS, sessionID, SessionsSubcollection.SECTIONS, id) as DocumentReference<SectionDoc, SectionDoc>, instance);
 }

--- a/src/data/firestore/sessions.ts
+++ b/src/data/firestore/sessions.ts
@@ -6,13 +6,12 @@ import {
   doc,
   Transaction,
   WriteBatch,
-  FirestoreDataConverter,
-  WithFieldValue,
   QueryDocumentSnapshot,
   DocumentReference,
   collection,
   CollectionReference,
-  UpdateData
+  UpdateData,
+  DocumentSnapshot
 } from "firebase/firestore";
 import {
   setDoc,
@@ -23,37 +22,35 @@ import {
 } from "./firestoreClientOperations";
 import { RootLevelCollection } from "./types/collections";
 
-const sessionFirestoreConverter: FirestoreDataConverter<Session, SessionDoc> = {
-  toFirestore: (
-    session: WithFieldValue<Session>
-  ): WithFieldValue<SessionDoc> => {
-    const { id, ...dto } = session;
-    return dto;
-  },
-  fromFirestore: (
-    snapshot: QueryDocumentSnapshot<SessionDoc, SessionDoc>
-  ): Session => ({ id: snapshot.ref.id, ...snapshot.data() }),
-};
+function fromFirestore(snapshot: DocumentSnapshot<SessionDoc, SessionDoc> | QueryDocumentSnapshot<SessionDoc, SessionDoc>): Session {
+  if (!snapshot.exists()) { throw Error("Document not found"); };
+  return {
+    id: snapshot.ref.id,
+    ...snapshot.data()
+  };
+}
 
 export async function getSessionById(id: string, transaction?: Transaction): Promise<Session> {
-  return await getDoc<Session, SessionDoc>(doc(db, RootLevelCollection.SESSIONS, id) as DocumentReference<Session, SessionDoc>, sessionFirestoreConverter, transaction);
+  const snapshot = await getDoc<SessionDoc>(doc(db, RootLevelCollection.SESSIONS, id) as DocumentReference<SessionDoc, SessionDoc>, transaction);
+  return fromFirestore(snapshot);
 }
 
 export async function getAllSessions(): Promise<Session[]> {
-  return await executeQuery<Session, SessionDoc>(collection(db, RootLevelCollection.SESSIONS) as CollectionReference<Session, SessionDoc>, sessionFirestoreConverter);
+  const snapshots = await executeQuery<SessionDoc>(collection(db, RootLevelCollection.SESSIONS) as CollectionReference<SessionDoc, SessionDoc>);
+  return snapshots.map(fromFirestore);
 }
 
 export type CreateSessionDTO = SessionDoc;
 export async function createSession(session: CreateSessionDTO, instance?: Transaction | WriteBatch): Promise<string> {
   const sessionId = uuid();
-  await setDoc<Session, SessionDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId) as DocumentReference<Session, SessionDoc>, { id: sessionId, ...session }, sessionFirestoreConverter, { instance });
+  await setDoc<SessionDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId) as DocumentReference<SessionDoc, SessionDoc>, session, { instance });
   return sessionId;
 }
 
 export async function updateSession(id: string, updates: UpdateData<SessionDoc>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<Session, SessionDoc>(doc(db, RootLevelCollection.SESSIONS, id) as DocumentReference<Session, SessionDoc>, updates, sessionFirestoreConverter, instance);
+  await updateDoc<SessionDoc>(doc(db, RootLevelCollection.SESSIONS, id) as DocumentReference<SessionDoc, SessionDoc>, updates, instance);
 }
 
 export async function deleteSession(id: string, instance?: Transaction | WriteBatch): Promise<void> {
-  await deleteDoc<Session, SessionDoc>(doc(db, RootLevelCollection.SESSIONS, id) as DocumentReference<Session, SessionDoc>, instance);
+  await deleteDoc<SessionDoc>(doc(db, RootLevelCollection.SESSIONS, id) as DocumentReference<SessionDoc, SessionDoc>, instance);
 }

--- a/src/data/firestore/users.ts
+++ b/src/data/firestore/users.ts
@@ -6,33 +6,33 @@ import {
   Transaction,
   WriteBatch,
   QueryDocumentSnapshot,
-  FirestoreDataConverter,
-  WithFieldValue,
   DocumentReference,
+  DocumentSnapshot,
 } from "firebase/firestore";
 import { setDoc, getDoc, updateDoc, deleteDoc } from "./firestoreClientOperations";
 import { RootLevelCollection } from "./types/collections";
 
-const userFirestoreConverter: FirestoreDataConverter<User, UserDoc> = {
-  toFirestore: (user: WithFieldValue<User>) => {
-    const { id, ...dto } = user;
-    return dto;
-  },
-  fromFirestore: (snapshot: QueryDocumentSnapshot<UserDoc, UserDoc>): User => ({ id: Number(snapshot.ref.id), ...snapshot.data() })
-};
+function fromFirestore(snapshot: DocumentSnapshot<UserDoc, UserDoc> | QueryDocumentSnapshot<UserDoc, UserDoc>): User {
+  if (!snapshot.exists()) { throw Error("Document not found"); }
+  return {
+    id: Number(snapshot.ref.id),
+    ...snapshot.data()
+  }
+}
 
 export async function getUserById(id: number, transaction?: Transaction): Promise<User> {
-  return await getDoc<User, UserDoc>(doc(db, RootLevelCollection.USERS, String(id)) as DocumentReference<User, UserDoc>, userFirestoreConverter, transaction);
+  const snapshot = await getDoc<UserDoc>(doc(db, RootLevelCollection.USERS, String(id)) as DocumentReference<UserDoc, UserDoc>, transaction);
+  return fromFirestore(snapshot);
 };
 
 export async function createUser(id: number, user: UserDoc, instance?: Transaction | WriteBatch): Promise<void> {
-  await setDoc<User, UserDoc>(doc(db, RootLevelCollection.USERS, String(id)) as DocumentReference<User, UserDoc>, { id, ...user }, userFirestoreConverter, { instance });
+  await setDoc<UserDoc>(doc(db, RootLevelCollection.USERS, String(id)) as DocumentReference<UserDoc, UserDoc>, user, { instance });
 }
 
 export async function updateUser(id: number, updates: Partial<UserDoc>, instance?: Transaction | WriteBatch): Promise<void> {
-  await updateDoc<User, UserDoc>(doc(db, RootLevelCollection.USERS, String(id)) as DocumentReference<User, UserDoc>, updates, userFirestoreConverter, instance);
+  await updateDoc<UserDoc>(doc(db, RootLevelCollection.USERS, String(id)) as DocumentReference<UserDoc, UserDoc>, updates, instance);
 }
 
 export async function deleteUser(id: number, instance?: Transaction | WriteBatch): Promise<void> {
-  await deleteDoc<User, UserDoc>(doc(db, RootLevelCollection.USERS, String(id)) as DocumentReference<User, UserDoc>, instance);
+  await deleteDoc<UserDoc>(doc(db, RootLevelCollection.USERS, String(id)) as DocumentReference<UserDoc, UserDoc>, instance);
 }


### PR DESCRIPTION
- Removed Firestore data converters from Firestore wrappers
- Modified Firestore read wrappers to return document snapshots
- Created custom mapper functions to map documents to frontend types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Firestore data mapping by replacing converter-based serialization with local helper functions across multiple data modules. Removed redundant type abstractions to streamline database operations while maintaining existing API contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->