### PR TITLE
refactor(sessions): change SessionCalendar implementation to use Mantine's MonthView component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@mantine/hooks": "^9.2.1",
         "@mantine/modals": "^9.2.1",
         "@mantine/notifications": "^9.2.1",
+        "@mantine/schedule": "^9.2.1",
         "@react-pdf/renderer": "^4.3.1",
         "@tanstack/react-form": "^1.27.7",
         "@tanstack/react-query": "^5.90.6",
@@ -3888,6 +3889,22 @@
       },
       "peerDependencies": {
         "@mantine/core": "9.2.1",
+        "@mantine/hooks": "9.2.1",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0"
+      }
+    },
+    "node_modules/@mantine/schedule": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@mantine/schedule/-/schedule-9.2.1.tgz",
+      "integrity": "sha512-NI3IqFUi6gKE/8FKizjWUVdZ8yArS5Nt4xMIV/zLgCC/7t4f2oUwf6XfZC23DmP/FiohLYPcWA7j2hV27E/2gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "rrule": "^2.8.1"
+      },
+      "peerDependencies": {
+        "@mantine/core": "9.2.1",
+        "@mantine/dates": "9.2.1",
         "@mantine/hooks": "9.2.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
@@ -14012,6 +14029,15 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rrule": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
+      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@mantine/hooks": "^9.2.1",
     "@mantine/modals": "^9.2.1",
     "@mantine/notifications": "^9.2.1",
+    "@mantine/schedule": "^9.2.1",
     "@react-pdf/renderer": "^4.3.1",
     "@tanstack/react-form": "^1.27.7",
     "@tanstack/react-query": "^5.90.6",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwind-preset-mantine";
 @import "@mantine/dates/styles.css" layer(mantine);
 @import "@mantine/notifications/styles.css" layer(mantine);
+@import "@mantine/schedule/styles.css" layer(mantine);
 @import "../styles/theme.css";

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -1,7 +1,16 @@
 import { Moment, weekdaysShort } from "moment";
 
 import React, { useState } from "react";
-import { SimpleGrid, Text, Box, Menu, Button, ActionIcon, Select, Title } from "@mantine/core";
+import {
+  SimpleGrid,
+  Text,
+  Box,
+  Menu,
+  Button,
+  ActionIcon,
+  Select,
+  Title,
+} from "@mantine/core";
 import { Session } from "@/types/sessions/sessionTypes";
 import moment from "moment";
 import classNames from "classnames";
@@ -52,101 +61,64 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
     weekStarts.push(weekStarts[weekStarts.length - 1].clone().add(1, "week"));
   }
 
-  const [selectedMonth, setSelectedMonth] = useState<Moment>(moment(session.startDate).startOf('month'));
+  const [selectedMonth, setSelectedMonth] = useState<Moment>(
+    moment(session.startDate).startOf("month"),
+  );
 
   return (
-    <>
-      <div>
-        <ScheduleHeader className="flex items-center">
-          <ActionIcon variant="outline" size="md" onClick={() => setSelectedMonth(prev => prev.clone().subtract(1, 'month'))} disabled={selectedMonth.isSame(session.startDate, "month")}>
-            <MdChevronLeft size={20} />
-          </ActionIcon>
-          <ActionIcon variant="outline" size="md" onClick={() => setSelectedMonth(prev => prev.clone().add(1, 'month'))} disabled={selectedMonth.isSame(session.endDate, "month")}>
-            <MdChevronRight size={20} />
-          </ActionIcon>
-          <Title order={4}>{selectedMonth.format("MMMM YYYY")}</Title>
-        </ScheduleHeader>
-        <MonthView
-          date={selectedMonth.toDate()}
-          classNames={{
-            monthViewInner: 'rounded-none',
-            monthViewWeek: 'rounded-none',
-            monthViewWeekday: 'rounded-none border border-solid border-neutral bg-neutral-0',
-          }}
-          getDayProps={(date) => {
-            const isInSession = moment(date).isBetween(session.startDate, session.endDate, "day", "[]");
-            return {
-              className: classNames('rounded-none border border-solid border-neutral text-black', {
+    <div>
+      <ScheduleHeader className="flex items-center">
+        <ActionIcon
+          variant="outline"
+          size="md"
+          onClick={() =>
+            setSelectedMonth((prev) => prev.clone().subtract(1, "month"))
+          }
+          disabled={selectedMonth.isSame(session.startDate, "month")}
+        >
+          <MdChevronLeft size={20} />
+        </ActionIcon>
+        <ActionIcon
+          variant="outline"
+          size="md"
+          onClick={() =>
+            setSelectedMonth((prev) => prev.clone().add(1, "month"))
+          }
+          disabled={selectedMonth.isSame(session.endDate, "month")}
+        >
+          <MdChevronRight size={20} />
+        </ActionIcon>
+        <Title order={4}>{selectedMonth.format("MMMM YYYY")}</Title>
+      </ScheduleHeader>
+      <MonthView
+        date={selectedMonth.toDate()}
+        classNames={{
+          monthViewInner: "rounded-none",
+          monthViewWeek: "rounded-none",
+          monthViewWeekday:
+            "rounded-none border border-solid border-neutral bg-neutral-0",
+        }}
+        getDayProps={(date) => {
+          const isInSession = moment(date).isBetween(
+            session.startDate,
+            session.endDate,
+            "day",
+            "[]",
+          );
+          return {
+            className: classNames(
+              "rounded-none border border-solid border-neutral text-black",
+              {
                 "bg-neutral-2 cursor-pointer": isInSession,
-                "bg-neutral-3 cursor-default": !isInSession
-              })
-            }
-          }}
-          consistentWeeks={false}
-          withHeader={false}
-          highlightToday={false}
-        />
-      </div>
-      <SimpleGrid className="grid-cols-7 gap-0 select-none w-full">
-        {weekdaysShort().map((day) => (
-          <Box
-            key={day}
-            className="p-xs bg-neutral-0 border border-solid border-neutral-5"
-          >
-            <Text className="text-sm text-center font-bold">{day}</Text>
-          </Box>
-        ))}
-        {weekStarts.map((weekStart) =>
-          Array.from({ length: 7 }, (_, i) =>
-            weekStart.clone().add(i, "day"),
-          ).map((day) => {
-            const isInSession = day.isBetween(
-              session.startDate,
-              session.endDate,
-              "day",
-              "[]",
-            );
-            const isInSelection =
-              firstSelectedDate &&
-              secondSelectedDate &&
-              day.isBetween(
-                firstSelectedDate.isSameOrBefore(secondSelectedDate)
-                  ? firstSelectedDate
-                  : secondSelectedDate,
-                firstSelectedDate.isSameOrBefore(secondSelectedDate)
-                  ? secondSelectedDate
-                  : firstSelectedDate,
-                "day",
-                "[]",
-              );
-
-            const eventHandlers = isInSession && {
-              onPointerDown: () => handlePointerDown(day),
-              onPointerEnter: () => handlePointerEnter(day),
-              onPointerUp: () => handlePointerUp(),
-            };
-
-            return (
-              <Box
-                key={day.format("YYYY-MM-DD")}
-                {...eventHandlers}
-                className={classNames(
-                  "p-xs border border-solid border-neutral-5 text-left min-h-52",
-                  {
-                    "bg-aqua-4": isInSession && isInSelection,
-                    "bg-neutral-2": isInSession && !isInSelection,
-                    "bg-neutral-3": !isInSession,
-                  },
-                )}
-              >
-                <Text className="text-sm font-bold text-center">
-                  {day.date()}
-                </Text>
-              </Box>
-            );
-          }),
-        )}
-      </SimpleGrid>
-    </>
+                "bg-neutral-3 cursor-default": !isInSession,
+              },
+            ),
+          };
+        }}
+        consistentWeeks={false}
+        withHeader={false}
+        highlightToday={false}
+      />
+    </div>
   );
 }

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -1,9 +1,6 @@
 import { Moment } from "moment";
 import { useMemo, useState } from "react";
-import {
-  ActionIcon,
-  Title,
-} from "@mantine/core";
+import { ActionIcon, Title, Tooltip } from "@mantine/core";
 import { Session } from "@/types/sessions/sessionTypes";
 import moment from "moment";
 import classNames from "classnames";
@@ -31,9 +28,12 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
     if (!firstSelectedDate || !secondSelectedDate) {
       return null;
     }
-    const startDate = firstSelectedDate.isBefore(secondSelectedDate) ? firstSelectedDate : secondSelectedDate;
-    const endDate = startDate === firstSelectedDate ? secondSelectedDate : firstSelectedDate;
-    return [startDate.clone().startOf('day'), endDate.clone().endOf('day')];
+    const startDate = firstSelectedDate.isBefore(secondSelectedDate)
+      ? firstSelectedDate
+      : secondSelectedDate;
+    const endDate =
+      startDate === firstSelectedDate ? secondSelectedDate : firstSelectedDate;
+    return [startDate.clone().startOf("day"), endDate.clone().endOf("day")];
   }, [firstSelectedDate, secondSelectedDate]);
 
   const handlePointerDown = (date: Moment) => {
@@ -54,32 +54,38 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
       sessionId: session.id,
       initialStartDate: startDate,
       initialEndDate: endDate,
-    })
-  }
+    });
+  };
 
   return (
     <div>
       <ScheduleHeader className="flex items-center">
-        <ActionIcon
-          variant="outline"
-          size="md"
-          onClick={() =>
-            setSelectedMonth((prev) => prev.clone().subtract(1, "month"))
-          }
-          disabled={selectedMonth.isSame(session.startDate, "month")}
-        >
-          <MdChevronLeft size={20} />
-        </ActionIcon>
-        <ActionIcon
-          variant="outline"
-          size="md"
-          onClick={() =>
-            setSelectedMonth((prev) => prev.clone().add(1, "month"))
-          }
-          disabled={selectedMonth.isSame(session.endDate, "month")}
-        >
-          <MdChevronRight size={20} />
-        </ActionIcon>
+        <Tooltip label="Previous month">
+          <ActionIcon
+            variant="outline"
+            size="md"
+            onClick={() =>
+              setSelectedMonth((prev) => prev.clone().subtract(1, "month"))
+            }
+            disabled={selectedMonth.isSame(session.startDate, "month")}
+            aria-label="Previous month"
+          >
+            <MdChevronLeft size={20} />
+          </ActionIcon>
+        </Tooltip>
+        <Tooltip label="Next month">
+          <ActionIcon
+            variant="outline"
+            size="md"
+            onClick={() =>
+              setSelectedMonth((prev) => prev.clone().add(1, "month"))
+            }
+            disabled={selectedMonth.isSame(session.endDate, "month")}
+            aria-label="Next month"
+          >
+            <MdChevronRight size={20} />
+          </ActionIcon>
+        </Tooltip>
         <Title order={4}>{selectedMonth.format("MMMM YYYY")}</Title>
       </ScheduleHeader>
       <MonthView
@@ -97,17 +103,30 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
             "day",
             "[]",
           );
-          const isInSelection = isInSession && selectedDates && moment(date).isBetween(selectedDates[0], selectedDates[1], "day", "[]");
-          const isInWeekWithSessionDate = momentRangesOverlap([moment(session.startDate), moment(session.endDate)], [moment(date).startOf('week'), moment(date).endOf('week')])
+          const isInSelection =
+            isInSession &&
+            selectedDates &&
+            moment(date).isBetween(
+              selectedDates[0],
+              selectedDates[1],
+              "day",
+              "[]",
+            );
+          const isInWeekWithSessionDate = momentRangesOverlap(
+            [moment(session.startDate), moment(session.endDate)],
+            [moment(date).startOf("week"), moment(date).endOf("week")],
+          );
           return {
             className: classNames(
               "rounded-none border border-solid border-neutral",
               {
                 "bg-neutral-2 cursor-pointer": isInSession && !isInSelection,
-                "bg-neutral-3 cursor-default text-transparent pointer-events-none": !isInSession,
+                "bg-neutral-3 cursor-default text-transparent pointer-events-none":
+                  !isInSession,
                 "bg-aqua-1 cursor-pointer": isInSelection,
-                "hidden": !isInWeekWithSessionDate,
-                "text-black": moment(date).isSame(selectedMonth, "month") && isInSession,
+                hidden: !isInWeekWithSessionDate,
+                "text-black":
+                  moment(date).isSame(selectedMonth, "month") && isInSession,
               },
             ),
             onMouseDown: () => handlePointerDown(moment(date)),
@@ -119,8 +138,18 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
         highlightToday={false}
         firstDayOfWeek={0}
         withDragSlotSelect
-        onDayClick={(date) => openCreateSectionModal(moment(date).startOf('day'), moment(date).startOf('day'))}
-        onSlotDragEnd={(rangeStart, rangeEnd) => openCreateSectionModal(moment(rangeStart).startOf('day'), moment(rangeEnd).startOf('day'))}
+        onDayClick={(date) =>
+          openCreateSectionModal(
+            moment(date).startOf("day"),
+            moment(date).startOf("day"),
+          )
+        }
+        onSlotDragEnd={(rangeStart, rangeEnd) =>
+          openCreateSectionModal(
+            moment(rangeStart).startOf("day"),
+            moment(rangeEnd).startOf("day"),
+          )
+        }
       />
     </div>
   );

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -1,11 +1,14 @@
 import { Moment, weekdaysShort } from "moment";
 
 import React, { useState } from "react";
-import { SimpleGrid, Text, Box } from "@mantine/core";
+import { SimpleGrid, Text, Box, Menu, Button, ActionIcon, Select, Title } from "@mantine/core";
 import { Session } from "@/types/sessions/sessionTypes";
 import moment from "moment";
 import classNames from "classnames";
 import openEditSectionModal from "@/components/EditSectionModal";
+import { MonthView, Schedule, ScheduleHeader } from "@mantine/schedule";
+import { MdChevronLeft, MdChevronRight } from "react-icons/md";
+import { getMonthDays } from "@mantine/dates";
 
 interface SessionCalendarProps {
   session: Session;
@@ -49,18 +52,33 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
     weekStarts.push(weekStarts[weekStarts.length - 1].clone().add(1, "week"));
   }
 
+  const [selectedMonth, setSelectedMonth] = useState<Moment>(moment(session.startDate).startOf('month'));
+
   return (
     <>
       <div>
         <ScheduleHeader className="flex items-center">
-          <ScheduleHeader.Previous />
-          <Title order={4}>May 2025</Title>
-          <ScheduleHeader.Next />
-          <ScheduleHeader.Today></ScheduleHeader.Today>
+          <ScheduleHeader.Previous onClick={() => setSelectedMonth(prev => prev.clone().subtract(1, 'month'))}/>
+          <ScheduleHeader.Next onClick={() => setSelectedMonth(prev => prev.clone().add(1, 'month'))}/>
+          <Title order={4}>{selectedMonth.format("MMMM YYYY")}</Title>
         </ScheduleHeader>
         <MonthView
+                date={selectedMonth.toDate()}
+          classNames={{
+            monthViewInner: 'rounded-none',
+            monthViewWeek: 'rounded-none',
+            monthViewWeekday: 'rounded-none border border-solid border-neutral bg-neutral-0',
+          }}
+          getDayProps={(date) => {
+            const isInSession = moment(date).isBetween(session.startDate, session.endDate, "day", "[]");
+            return {
+              className: classNames('rounded-none border border-solid border-neutral text-black', {
+                "bg-neutral-2": isInSession,
+                "bg-neutral-3": !isInSession
+              })
+            }
+          }}
           withHeader={false}
-          date={moment(session.startDate).toDate()}
         />
       </div>
       <SimpleGrid className="grid-cols-7 gap-0 select-none w-full">

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -58,8 +58,12 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
     <>
       <div>
         <ScheduleHeader className="flex items-center">
-          <ScheduleHeader.Previous onClick={() => setSelectedMonth(prev => prev.clone().subtract(1, 'month'))}/>
-          <ScheduleHeader.Next onClick={() => setSelectedMonth(prev => prev.clone().add(1, 'month'))}/>
+          <ActionIcon variant="outline" size="md" onClick={() => setSelectedMonth(prev => prev.clone().subtract(1, 'month'))} disabled={selectedMonth.isSame(session.startDate, "month")}>
+            <MdChevronLeft size={20} />
+          </ActionIcon>
+          <ActionIcon variant="outline" size="md" onClick={() => setSelectedMonth(prev => prev.clone().add(1, 'month'))} disabled={selectedMonth.isSame(session.endDate, "month")}>
+            <MdChevronRight size={20} />
+          </ActionIcon>
           <Title order={4}>{selectedMonth.format("MMMM YYYY")}</Title>
         </ScheduleHeader>
         <MonthView

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -120,7 +120,7 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
         firstDayOfWeek={0}
         withDragSlotSelect
         onDayClick={(date) => openCreateSectionModal(moment(date).startOf('day'), moment(date).startOf('day'))}
-        onSlotDragEnd={(rangeStart, rangeEnd) => {console.log(rangeStart, rangeEnd); openCreateSectionModal(moment(rangeStart).startOf('day'), moment(rangeEnd).startOf('day'))}}
+        onSlotDragEnd={(rangeStart, rangeEnd) => openCreateSectionModal(moment(rangeStart).startOf('day'), moment(rangeEnd).startOf('day'))}
       />
     </div>
   );

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -20,7 +20,7 @@ import { MdChevronLeft, MdChevronRight } from "react-icons/md";
 import { getMonthDays } from "@mantine/dates";
 
 function momentRangesOverlap(range1: [Moment, Moment], range2: [Moment, Moment]): boolean {
-  return range1[0].isBefore(range2[1]) && range1[1].isAfter(range2[0]);
+  return range1[0].isBefore(range2[1]) && range2[0].isBefore(range1[1]);
 }
 
 interface SessionCalendarProps {

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -63,7 +63,7 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
           <Title order={4}>{selectedMonth.format("MMMM YYYY")}</Title>
         </ScheduleHeader>
         <MonthView
-                date={selectedMonth.toDate()}
+          date={selectedMonth.toDate()}
           classNames={{
             monthViewInner: 'rounded-none',
             monthViewWeek: 'rounded-none',
@@ -73,11 +73,12 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
             const isInSession = moment(date).isBetween(session.startDate, session.endDate, "day", "[]");
             return {
               className: classNames('rounded-none border border-solid border-neutral text-black', {
-                "bg-neutral-2": isInSession,
-                "bg-neutral-3": !isInSession
+                "bg-neutral-2 cursor-pointer": isInSession,
+                "bg-neutral-3 cursor-default": !isInSession
               })
             }
           }}
+          consistentWeeks={false}
           withHeader={false}
         />
       </div>

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -35,17 +35,13 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
     null,
   );
 
-  console.log("BRUH", [firstSelectedDate, secondSelectedDate]);
-
   const handlePointerDown = (date: Moment) => {
-    console.log('pointer down')
     setFirstSelectedDate(date);
     setSecondSelectedDate(date);
   };
 
   const isSelecting = firstSelectedDate !== null && secondSelectedDate !== null;
   const handlePointerEnter = (date: Moment) => {
-    console.log('firing')
     if (isSelecting) {
       setSecondSelectedDate(date);
     }
@@ -124,7 +120,7 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
             "[]",
           );
           const isInSelection = isInSession && firstSelectedDate && secondSelectedDate && momentRangesOverlap([firstSelectedDate, secondSelectedDate.clone().add(1, 'day')], [moment(date), moment(date).add(1, 'day')]);
-          const isInWeekWithSessionDate = momentRangesOverlap([moment(session.startDate), moment(session.endDate)], [moment(date).startOf('week'), moment(date).startOf('week').add(1, 'week')])
+          const isInWeekWithSessionDate = momentRangesOverlap([moment(session.startDate), moment(session.endDate)], [moment(date).startOf('week'), moment(date).endOf('week')])
           return {
             className: classNames(
               "rounded-none border border-solid border-neutral",

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -50,65 +50,79 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
   }
 
   return (
-    <SimpleGrid className="grid-cols-7 gap-0 select-none w-full">
-      {weekdaysShort().map((day) => (
-        <Box
-          key={day}
-          className="p-xs bg-neutral-0 border border-solid border-neutral-5"
-        >
-          <Text className="text-sm text-center font-bold">{day}</Text>
-        </Box>
-      ))}
-      {weekStarts.map((weekStart) =>
-        Array.from({ length: 7 }, (_, i) =>
-          weekStart.clone().add(i, "day"),
-        ).map((day) => {
-          const isInSession = day.isBetween(
-            session.startDate,
-            session.endDate,
-            "day",
-            "[]",
-          );
-          const isInSelection =
-            firstSelectedDate &&
-            secondSelectedDate &&
-            day.isBetween(
-              firstSelectedDate.isSameOrBefore(secondSelectedDate)
-                ? firstSelectedDate
-                : secondSelectedDate,
-              firstSelectedDate.isSameOrBefore(secondSelectedDate)
-                ? secondSelectedDate
-                : firstSelectedDate,
+    <>
+      <div>
+        <ScheduleHeader className="flex items-center">
+          <ScheduleHeader.Previous />
+          <Title order={4}>May 2025</Title>
+          <ScheduleHeader.Next />
+          <ScheduleHeader.Today></ScheduleHeader.Today>
+        </ScheduleHeader>
+        <MonthView
+          withHeader={false}
+          date={moment(session.startDate).toDate()}
+        />
+      </div>
+      <SimpleGrid className="grid-cols-7 gap-0 select-none w-full">
+        {weekdaysShort().map((day) => (
+          <Box
+            key={day}
+            className="p-xs bg-neutral-0 border border-solid border-neutral-5"
+          >
+            <Text className="text-sm text-center font-bold">{day}</Text>
+          </Box>
+        ))}
+        {weekStarts.map((weekStart) =>
+          Array.from({ length: 7 }, (_, i) =>
+            weekStart.clone().add(i, "day"),
+          ).map((day) => {
+            const isInSession = day.isBetween(
+              session.startDate,
+              session.endDate,
               "day",
               "[]",
             );
+            const isInSelection =
+              firstSelectedDate &&
+              secondSelectedDate &&
+              day.isBetween(
+                firstSelectedDate.isSameOrBefore(secondSelectedDate)
+                  ? firstSelectedDate
+                  : secondSelectedDate,
+                firstSelectedDate.isSameOrBefore(secondSelectedDate)
+                  ? secondSelectedDate
+                  : firstSelectedDate,
+                "day",
+                "[]",
+              );
 
-          const eventHandlers = isInSession && {
-            onPointerDown: () => handlePointerDown(day),
-            onPointerEnter: () => handlePointerEnter(day),
-            onPointerUp: () => handlePointerUp(),
-          };
+            const eventHandlers = isInSession && {
+              onPointerDown: () => handlePointerDown(day),
+              onPointerEnter: () => handlePointerEnter(day),
+              onPointerUp: () => handlePointerUp(),
+            };
 
-          return (
-            <Box
-              key={day.format("YYYY-MM-DD")}
-              {...eventHandlers}
-              className={classNames(
-                "p-xs border border-solid border-neutral-5 text-left min-h-52",
-                {
-                  "bg-aqua-4": isInSession && isInSelection,
-                  "bg-neutral-2": isInSession && !isInSelection,
-                  "bg-neutral-3": !isInSession,
-                },
-              )}
-            >
-              <Text className="text-sm font-bold text-center">
-                {day.date()}
-              </Text>
-            </Box>
-          );
-        }),
-      )}
-    </SimpleGrid>
+            return (
+              <Box
+                key={day.format("YYYY-MM-DD")}
+                {...eventHandlers}
+                className={classNames(
+                  "p-xs border border-solid border-neutral-5 text-left min-h-52",
+                  {
+                    "bg-aqua-4": isInSession && isInSelection,
+                    "bg-neutral-2": isInSession && !isInSelection,
+                    "bg-neutral-3": !isInSession,
+                  },
+                )}
+              >
+                <Text className="text-sm font-bold text-center">
+                  {day.date()}
+                </Text>
+              </Box>
+            );
+          }),
+        )}
+      </SimpleGrid>
+    </>
   );
 }

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -115,9 +115,9 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
               "rounded-none border border-solid border-neutral",
               {
                 "bg-neutral-2 cursor-pointer": isInSession,
-                "bg-neutral-3 cursor-default": !isInSession,
+                "bg-neutral-3 cursor-default text-transparent": !isInSession,
                 "hidden": !isInWeekWithSessionDate,
-                "text-black": moment(date).isSame(selectedMonth, "month"),
+                "text-black": moment(date).isSame(selectedMonth, "month") && isInSession,
               },
             ),
           };

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -10,10 +10,7 @@ import classNames from "classnames";
 import openEditSectionModal from "@/components/EditSectionModal";
 import { MonthView, ScheduleHeader } from "@mantine/schedule";
 import { MdChevronLeft, MdChevronRight } from "react-icons/md";
-
-function momentRangesOverlap(range1: [Moment, Moment], range2: [Moment, Moment]): boolean {
-  return range1[0].isBefore(range2[1]) && range2[0].isBefore(range1[1]);
-}
+import { momentRangesOverlap } from "@/utils/timeUtils";
 
 interface SessionCalendarProps {
   session: Session;

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -47,24 +47,6 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
     }
   };
 
-  const handlePointerUp = () => {
-    if (isSelecting) {
-      openEditSectionModal({
-        sessionId: session.id,
-        initialStartDate: firstSelectedDate,
-        initialEndDate: secondSelectedDate,
-      });
-    }
-    setFirstSelectedDate(null);
-    setSecondSelectedDate(null);
-  };
-
-  const weekStarts = [moment(session.startDate).startOf("week")];
-  const lastWeekStart = moment(session.endDate).clone().startOf("week");
-  while (weekStarts[weekStarts.length - 1].isBefore(lastWeekStart)) {
-    weekStarts.push(weekStarts[weekStarts.length - 1].clone().add(1, "week"));
-  }
-
   const [selectedMonth, setSelectedMonth] = useState<Moment>(
     moment(session.startDate).startOf("month"),
   );

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -104,7 +104,7 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
               "rounded-none border border-solid border-neutral",
               {
                 "bg-neutral-2 cursor-pointer": isInSession && !isInSelection,
-                "bg-neutral-3 cursor-default text-transparent": !isInSession,
+                "bg-neutral-3 cursor-default text-transparent pointer-events-none": !isInSession,
                 "bg-aqua-1 cursor-pointer": isInSelection,
                 "hidden": !isInWeekWithSessionDate,
                 "text-black": moment(date).isSame(selectedMonth, "month") && isInSession,

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -84,6 +84,7 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
           }}
           consistentWeeks={false}
           withHeader={false}
+          highlightToday={false}
         />
       </div>
       <SimpleGrid className="grid-cols-7 gap-0 select-none w-full">

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -19,6 +19,10 @@ import { MonthView, Schedule, ScheduleHeader } from "@mantine/schedule";
 import { MdChevronLeft, MdChevronRight } from "react-icons/md";
 import { getMonthDays } from "@mantine/dates";
 
+function momentRangesOverlap(range1: [Moment, Moment], range2: [Moment, Moment]): boolean {
+  return range1[0].isBefore(range2[1]) && range1[1].isAfter(range2[0]);
+}
+
 interface SessionCalendarProps {
   session: Session;
 }
@@ -105,12 +109,15 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
             "day",
             "[]",
           );
+          const isInWeekWithSessionDate = momentRangesOverlap([moment(session.startDate), moment(session.endDate)], [moment(date).startOf('week'), moment(date).startOf('week').add(6, 'days')])
           return {
             className: classNames(
-              "rounded-none border border-solid border-neutral text-black",
+              "rounded-none border border-solid border-neutral",
               {
                 "bg-neutral-2 cursor-pointer": isInSession,
                 "bg-neutral-3 cursor-default": !isInSession,
+                "hidden": !isInWeekWithSessionDate,
+                "text-black": moment(date).isSame(selectedMonth, "month"),
               },
             ),
           };
@@ -118,6 +125,7 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
         consistentWeeks={false}
         withHeader={false}
         highlightToday={false}
+        firstDayOfWeek={0}
       />
     </div>
   );

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -28,6 +28,9 @@ interface SessionCalendarProps {
 }
 
 export default function SessionCalendar({ session }: SessionCalendarProps) {
+  const [selectedMonth, setSelectedMonth] = useState<Moment>(
+    moment(session.startDate).startOf("month"),
+  );
   const [firstSelectedDate, setFirstSelectedDate] = useState<Moment | null>(
     null,
   );
@@ -54,10 +57,6 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
       setSecondSelectedDate(date);
     }
   };
-
-  const [selectedMonth, setSelectedMonth] = useState<Moment>(
-    moment(session.startDate).startOf("month"),
-  );
 
   const openCreateSectionModal = (startDate: Moment, endDate: Moment) => {
     setFirstSelectedDate(null);

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -136,9 +136,8 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
                 "text-black": moment(date).isSame(selectedMonth, "month") && isInSession,
               },
             ),
-            onMouseDown: (e) =>{handlePointerDown(moment(date))},
+            onMouseDown: () => handlePointerDown(moment(date)),
             onPointerEnter: () => handlePointerEnter(moment(date)),
-            onPointerUp: handlePointerUp
           };
         }}
         consistentWeeks={false}
@@ -147,7 +146,7 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
         firstDayOfWeek={0}
         withDragSlotSelect
         onDayClick={(date) => openCreateSectionModal(moment(date).startOf('day'), moment(date).startOf('day'))}
-        onSlotDragEnd={(rangeStart, rangeEnd) => openCreateSectionModal(moment(rangeStart).startOf('day'), moment(rangeEnd).startOf('day'))}
+        onSlotDragEnd={(rangeStart, rangeEnd) => {console.log(rangeStart, rangeEnd); openCreateSectionModal(moment(rangeStart).startOf('day'), moment(rangeEnd).startOf('day'))}}
       />
     </div>
   );

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -72,6 +72,14 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
     moment(session.startDate).startOf("month"),
   );
 
+  const openCreateSectionModal = (startDate: Moment, endDate: Moment) => {
+    openEditSectionModal({
+      sessionId: session.id,
+      initialStartDate: startDate,
+      initialEndDate: endDate,
+    })
+  }
+
   return (
     <div>
       <ScheduleHeader className="flex items-center">
@@ -133,14 +141,8 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
         highlightToday={false}
         firstDayOfWeek={0}
         withDragSlotSelect
-        onDayClick={(date) => {
-          setFirstSelectedDate(moment(date));
-          setSecondSelectedDate(moment(date));
-        }}
-        onSlotDragEnd={(rangeStart, rangeEnd) => {
-          setFirstSelectedDate(null);
-          setSecondSelectedDate(null);
-        }}
+        onDayClick={(date) => openCreateSectionModal(moment(date).startOf('day'), moment(date).startOf('day'))}
+        onSlotDragEnd={(rangeStart, rangeEnd) => openCreateSectionModal(moment(rangeStart).startOf('day'), moment(rangeEnd).startOf('day'))}
       />
     </div>
   );

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -35,9 +35,10 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
     null,
   );
 
-  console.log([firstSelectedDate, secondSelectedDate]);
+  console.log("BRUH", [firstSelectedDate, secondSelectedDate]);
 
   const handlePointerDown = (date: Moment) => {
+    console.log('pointer down')
     setFirstSelectedDate(date);
     setSecondSelectedDate(date);
   };
@@ -120,7 +121,7 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
             "day",
             "[]",
           );
-          const isInSelection = isInSession && false;
+          const isInSelection = isInSession && firstSelectedDate && secondSelectedDate && momentRangesOverlap([firstSelectedDate, secondSelectedDate.clone().add(1, 'day')], [moment(date), moment(date).add(1, 'day')]);
           const isInWeekWithSessionDate = momentRangesOverlap([moment(session.startDate), moment(session.endDate)], [moment(date).startOf('week'), moment(date).startOf('week').add(1, 'week')])
           return {
             className: classNames(
@@ -133,7 +134,9 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
                 "text-black": moment(date).isSame(selectedMonth, "month") && isInSession,
               },
             ),
-            handlePointerEnter
+            onMouseDown: (e) =>{handlePointerDown(moment(date))},
+            onPointerEnter: () => handlePointerEnter(moment(date)),
+            onPointerUp: handlePointerUp
           };
         }}
         consistentWeeks={false}

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -1,23 +1,15 @@
-import { Moment, weekdaysShort } from "moment";
-
-import React, { useMemo, useState } from "react";
+import { Moment } from "moment";
+import { useMemo, useState } from "react";
 import {
-  SimpleGrid,
-  Text,
-  Box,
-  Menu,
-  Button,
   ActionIcon,
-  Select,
   Title,
 } from "@mantine/core";
 import { Session } from "@/types/sessions/sessionTypes";
 import moment from "moment";
 import classNames from "classnames";
 import openEditSectionModal from "@/components/EditSectionModal";
-import { MonthView, Schedule, ScheduleHeader } from "@mantine/schedule";
+import { MonthView, ScheduleHeader } from "@mantine/schedule";
 import { MdChevronLeft, MdChevronRight } from "react-icons/md";
-import { getMonthDays } from "@mantine/dates";
 
 function momentRangesOverlap(range1: [Moment, Moment], range2: [Moment, Moment]): boolean {
   return range1[0].isBefore(range2[1]) && range2[0].isBefore(range1[1]);

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -35,6 +35,8 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
     null,
   );
 
+  console.log([firstSelectedDate, secondSelectedDate]);
+
   const handlePointerDown = (date: Moment) => {
     setFirstSelectedDate(date);
     setSecondSelectedDate(date);
@@ -42,6 +44,7 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
 
   const isSelecting = firstSelectedDate !== null && secondSelectedDate !== null;
   const handlePointerEnter = (date: Moment) => {
+    console.log('firing')
     if (isSelecting) {
       setSecondSelectedDate(date);
     }
@@ -109,23 +112,35 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
             "day",
             "[]",
           );
-          const isInWeekWithSessionDate = momentRangesOverlap([moment(session.startDate), moment(session.endDate)], [moment(date).startOf('week'), moment(date).startOf('week').add(6, 'days')])
+          const isInSelection = isInSession && false;
+          const isInWeekWithSessionDate = momentRangesOverlap([moment(session.startDate), moment(session.endDate)], [moment(date).startOf('week'), moment(date).startOf('week').add(1, 'week')])
           return {
             className: classNames(
               "rounded-none border border-solid border-neutral",
               {
-                "bg-neutral-2 cursor-pointer": isInSession,
+                "bg-neutral-2 cursor-pointer": isInSession && !isInSelection,
                 "bg-neutral-3 cursor-default text-transparent": !isInSession,
+                "bg-aqua-4 cursor-pointer": isInSelection,
                 "hidden": !isInWeekWithSessionDate,
                 "text-black": moment(date).isSame(selectedMonth, "month") && isInSession,
               },
             ),
+            handlePointerEnter
           };
         }}
         consistentWeeks={false}
         withHeader={false}
         highlightToday={false}
         firstDayOfWeek={0}
+        withDragSlotSelect
+        onDayClick={(date) => {
+          setFirstSelectedDate(moment(date));
+          setSecondSelectedDate(moment(date));
+        }}
+        onSlotDragEnd={(rangeStart, rangeEnd) => {
+          setFirstSelectedDate(null);
+          setSecondSelectedDate(null);
+        }}
       />
     </div>
   );

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -74,6 +74,8 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
   );
 
   const openCreateSectionModal = (startDate: Moment, endDate: Moment) => {
+    setFirstSelectedDate(null);
+    setSecondSelectedDate(null);
     openEditSectionModal({
       sessionId: session.id,
       initialStartDate: startDate,

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -129,7 +129,7 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
               {
                 "bg-neutral-2 cursor-pointer": isInSession && !isInSelection,
                 "bg-neutral-3 cursor-default text-transparent": !isInSession,
-                "bg-aqua-4 cursor-pointer": isInSelection,
+                "bg-aqua-1 cursor-pointer": isInSelection,
                 "hidden": !isInWeekWithSessionDate,
                 "text-black": moment(date).isSame(selectedMonth, "month") && isInSession,
               },

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -1,6 +1,6 @@
 import { Moment, weekdaysShort } from "moment";
 
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   SimpleGrid,
   Text,
@@ -35,14 +35,22 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
     null,
   );
 
+  const selectedDates = useMemo(() => {
+    if (!firstSelectedDate || !secondSelectedDate) {
+      return null;
+    }
+    const startDate = firstSelectedDate.isBefore(secondSelectedDate) ? firstSelectedDate : secondSelectedDate;
+    const endDate = startDate === firstSelectedDate ? secondSelectedDate : firstSelectedDate;
+    return [startDate.clone().startOf('day'), endDate.clone().endOf('day')];
+  }, [firstSelectedDate, secondSelectedDate]);
+
   const handlePointerDown = (date: Moment) => {
     setFirstSelectedDate(date);
     setSecondSelectedDate(date);
   };
 
-  const isSelecting = firstSelectedDate !== null && secondSelectedDate !== null;
   const handlePointerEnter = (date: Moment) => {
-    if (isSelecting) {
+    if (firstSelectedDate !== null && secondSelectedDate !== null) {
       setSecondSelectedDate(date);
     }
   };
@@ -101,7 +109,7 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
             "day",
             "[]",
           );
-          const isInSelection = isInSession && firstSelectedDate && secondSelectedDate && momentRangesOverlap([firstSelectedDate, secondSelectedDate.clone().add(1, 'day')], [moment(date), moment(date).add(1, 'day')]);
+          const isInSelection = isInSession && selectedDates && moment(date).isBetween(selectedDates[0], selectedDates[1], "day", "[]");
           const isInWeekWithSessionDate = momentRangesOverlap([moment(session.startDate), moment(session.endDate)], [moment(date).startOf('week'), moment(date).endOf('week')])
           return {
             className: classNames(

--- a/src/hooks/sessions/useCreateSession.ts
+++ b/src/hooks/sessions/useCreateSession.ts
@@ -13,8 +13,8 @@ async function createSession(req: CreateSessionRequest) {
   const { name, startDate, endDate } = req;
   await createSessionDoc({
     name,
-    startDate: Timestamp.fromDate(startDate.toDate()),
-    endDate: Timestamp.fromDate(endDate.toDate()),
+    startDate: Timestamp.fromDate(startDate.clone().startOf('day').toDate()),
+    endDate: Timestamp.fromDate(endDate.clone().endOf('day').toDate()),
     attendeeIds: []
   });
 }

--- a/src/styles/components/ActionIconThemeExtension.ts
+++ b/src/styles/components/ActionIconThemeExtension.ts
@@ -4,7 +4,7 @@ import classNames from "classnames";
 const ActionItemThemeExtension = ActionIcon.extend({
   classNames: (_theme, props, _ctx) => {
     return {
-      root: classNames('border-2', {
+      root: classNames({
         'hover:rounded-xl hover:bg-[#00000010]': props.variant === "transparent"
       })
     }

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -1,0 +1,5 @@
+import { Moment } from "moment";
+
+export function momentRangesOverlap(range1: [Moment, Moment], range2: [Moment, Moment]): boolean {
+  return range1[0].isBefore(range2[1]) && range2[0].isBefore(range1[1]);
+}


### PR DESCRIPTION
- Swapped out current SessionCalendar implementation with Mantine v9's new MonthView component from the new `@mantine/schedule` package
  - Component has built-in event support and handles styling better than the current component, so it made sense to swap it out
- Added month control with previous/next buttons
- Stopped rendering day labels for days that are not in the session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned calendar interface for session scheduling featuring month view navigation, interactive date selection (supporting both click-based and drag-and-drop interactions), and visual indicators for selected date ranges.
  * Enhanced section creation experience with streamlined modal access triggered directly from calendar date interactions, reducing workflow steps.

* **Bug Fixes**
  * Improved date boundary handling to normalize session start dates to day beginnings and end dates to day endings, ensuring consistent date processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hack4Impact-UMD/camp-starfish/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->