### PR TITLE
feat(sessions): add section badges to SessionCalendar

### DIFF
--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -61,7 +61,6 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
     color: sectionTypeToEventColor[section.type],
     variant: 'filled'
   }));
-  console.log(events)
 
   const handlePointerDown = (date: Moment) => {
     setFirstSelectedDate(date);

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -177,6 +177,11 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
             moment(rangeEnd).endOf("day"),
           )
         }
+        moreEventsProps={{
+          classNames: {
+            moreEventsDropdown: "rounded-sm"
+          }
+        }}
       />
     </div>
   );

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -1,7 +1,7 @@
 import { Moment } from "moment";
 import { useMemo, useState } from "react";
 import { ActionIcon, Title, Tooltip } from "@mantine/core";
-import { Session } from "@/types/sessions/sessionTypes";
+import { SectionType, Session } from "@/types/sessions/sessionTypes";
 import moment from "moment";
 import classNames from "classnames";
 import openEditSectionModal from "@/components/EditSectionModal";
@@ -10,6 +10,13 @@ import { MdChevronLeft, MdChevronRight } from "react-icons/md";
 import { momentRangesOverlap } from "@/utils/timeUtils";
 import useSectionList from "@/hooks/sections/useSectionList";
 import LoadingAnimation from "@/components/LoadingAnimation";
+
+const sectionTypeToEventColor: Record<SectionType, ScheduleSingleEventData['color']> = {
+  "COMMON": "blue",
+  "BUNDLE": "orange",
+  "BUNK-JAMBO": "green",
+  "NON-BUNK-JAMBO": "aqua"
+}
 
 interface SessionCalendarProps {
   session: Session;
@@ -51,8 +58,8 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
     title: section.name,
     start: section.startDate.toDate(),
     end: section.endDate.toDate(),
-    color: '#ff0000',
-    variant: "filled"
+    color: sectionTypeToEventColor[section.type],
+    variant: 'filled'
   }));
   console.log(events)
 

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -52,6 +52,7 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
     start: section.startDate.toDate(),
     end: section.endDate.toDate(),
     color: '#ff0000',
+    variant: "filled"
   }));
   console.log(events)
 

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -10,6 +10,7 @@ import { MdChevronLeft, MdChevronRight } from "react-icons/md";
 import { momentRangesOverlap } from "@/utils/timeUtils";
 import useSectionList from "@/hooks/sections/useSectionList";
 import LoadingAnimation from "@/components/LoadingAnimation";
+import { useRouter } from "next/navigation";
 
 const sectionTypeToEventColor: Record<SectionType, ScheduleSingleEventData['color']> = {
   "COMMON": "blue",
@@ -44,6 +45,8 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
       startDate === firstSelectedDate ? secondSelectedDate : firstSelectedDate;
     return [startDate.clone().startOf("day"), endDate.clone().endOf("day")];
   }, [firstSelectedDate, secondSelectedDate]);
+
+  const router = useRouter();
 
   const sectionsQuery = useSectionList(session.id, { orderBy: [{ fieldPath: "startDate", direction: "asc" }] });
 
@@ -177,6 +180,7 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
             moment(rangeEnd).endOf("day"),
           )
         }
+        onEventClick={(event) => router.push(`/sessions/${session.id}/${event.id}`)}
         moreEventsProps={{
           classNames: {
             moreEventsDropdown: "rounded-sm"

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -1,7 +1,7 @@
 import { Moment } from "moment";
 import { useMemo, useState } from "react";
 import { ActionIcon, Title, Tooltip } from "@mantine/core";
-import { SectionType, Session } from "@/types/sessions/sessionTypes";
+import { Section, SectionType, Session } from "@/types/sessions/sessionTypes";
 import moment from "moment";
 import classNames from "classnames";
 import openEditSectionModal from "@/components/EditSectionModal";
@@ -61,8 +61,9 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
     title: section.name,
     start: section.startDate.toDate(),
     end: section.endDate.toDate(),
+    payload: section,
     color: sectionTypeToEventColor[section.type],
-    variant: 'filled'
+    variant: 'filled',
   }));
 
   const handlePointerDown = (date: Moment) => {
@@ -180,7 +181,11 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
             moment(rangeEnd).endOf("day"),
           )
         }
-        onEventClick={(event) => router.push(`/sessions/${session.id}/${event.id}`)}
+        onEventClick={(event) => {
+          if ((event.payload as Section).type !== "COMMON") {
+            router.push(`/sessions/${session.id}/${event.id}`)
+          }
+        }}
         moreEventsProps={{
           classNames: {
             moreEventsDropdown: "rounded-sm"

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -11,6 +11,28 @@ import { momentRangesOverlap } from "@/utils/timeUtils";
 import useSectionList from "@/hooks/sections/useSectionList";
 import LoadingAnimation from "@/components/LoadingAnimation";
 import { useRouter } from "next/navigation";
+import useSession from "@/hooks/sessions/useSession";
+import ErrorPage from "@/app/error";
+
+interface SessionCalendarProps {
+  sessionId: string;
+}
+
+export default function SessionCalendar(props: SessionCalendarProps) {
+  const { sessionId } = props;
+  const sessionQuery = useSession(sessionId);
+  const sectionsQuery = useSectionList(sessionId, { orderBy: [{ fieldPath: "startDate", direction: "asc" }] });
+
+  if (sessionQuery.isPending || sectionsQuery.isPending) {
+    return <LoadingAnimation />;
+  } else if (sessionQuery.isError) {
+    return <ErrorPage error={sessionQuery.error} />;
+  } else if (sectionsQuery.isError) {
+    return <ErrorPage error={sectionsQuery.error} />;
+  } else {
+    return <SessionCalendarContent session={sessionQuery.data} sections={sectionsQuery.data} />;
+  }
+}
 
 const sectionTypeToEventColor: Record<SectionType, ScheduleSingleEventData['color']> = {
   "COMMON": "blue",
@@ -19,11 +41,14 @@ const sectionTypeToEventColor: Record<SectionType, ScheduleSingleEventData['colo
   "NON-BUNK-JAMBO": "aqua"
 }
 
-interface SessionCalendarProps {
+interface SessionCalendarContentProps {
   session: Session;
+  sections: Section[];
 }
 
-export default function SessionCalendar({ session }: SessionCalendarProps) {
+function SessionCalendarContent(props: SessionCalendarContentProps) {
+  const { session, sections } = props;
+
   const [selectedMonth, setSelectedMonth] = useState<Moment>(
     moment(session.startDate).startOf("month"),
   );
@@ -48,15 +73,7 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
 
   const router = useRouter();
 
-  const sectionsQuery = useSectionList(session.id, { orderBy: [{ fieldPath: "startDate", direction: "asc" }] });
-
-  if (sectionsQuery.isError) {
-    return <p>{sectionsQuery.error.message}</p>;
-  } else if (sectionsQuery.isPending) {
-    return <LoadingAnimation />;
-  }
-
-  const events: ScheduleSingleEventData[] = sectionsQuery.data.map(section => ({
+  const events: ScheduleSingleEventData[] = sections.map(section => ({
     id: section.id,
     title: section.name,
     start: section.startDate.toDate(),

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -5,9 +5,11 @@ import { Session } from "@/types/sessions/sessionTypes";
 import moment from "moment";
 import classNames from "classnames";
 import openEditSectionModal from "@/components/EditSectionModal";
-import { MonthView, ScheduleHeader } from "@mantine/schedule";
+import { MonthView, ScheduleHeader, ScheduleSingleEventData } from "@mantine/schedule";
 import { MdChevronLeft, MdChevronRight } from "react-icons/md";
 import { momentRangesOverlap } from "@/utils/timeUtils";
+import useSectionList from "@/hooks/sections/useSectionList";
+import LoadingAnimation from "@/components/LoadingAnimation";
 
 interface SessionCalendarProps {
   session: Session;
@@ -35,6 +37,23 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
       startDate === firstSelectedDate ? secondSelectedDate : firstSelectedDate;
     return [startDate.clone().startOf("day"), endDate.clone().endOf("day")];
   }, [firstSelectedDate, secondSelectedDate]);
+
+  const sectionsQuery = useSectionList(session.id, { orderBy: [{ fieldPath: "startDate", direction: "asc" }] });
+
+  if (sectionsQuery.isError) {
+    return <p>{sectionsQuery.error.message}</p>;
+  } else if (sectionsQuery.isPending) {
+    return <LoadingAnimation />;
+  }
+
+  const events: ScheduleSingleEventData[] = sectionsQuery.data.map(section => ({
+    id: section.id,
+    title: section.name,
+    start: section.startDate.toDate(),
+    end: section.endDate.toDate(),
+    color: '#ff0000',
+  }));
+  console.log(events)
 
   const handlePointerDown = (date: Moment) => {
     setFirstSelectedDate(date);
@@ -90,6 +109,7 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
       </ScheduleHeader>
       <MonthView
         date={selectedMonth.toDate()}
+        events={events}
         classNames={{
           monthViewInner: "rounded-none",
           monthViewWeek: "rounded-none",
@@ -141,13 +161,13 @@ export default function SessionCalendar({ session }: SessionCalendarProps) {
         onDayClick={(date) =>
           openCreateSectionModal(
             moment(date).startOf("day"),
-            moment(date).startOf("day"),
+            moment(date).endOf("day"),
           )
         }
         onSlotDragEnd={(rangeStart, rangeEnd) =>
           openCreateSectionModal(
             moment(rangeStart).startOf("day"),
-            moment(rangeEnd).startOf("day"),
+            moment(rangeEnd).endOf("day"),
           )
         }
       />

--- a/src/app/sessions/[sessionId]/SessionPage.tsx
+++ b/src/app/sessions/[sessionId]/SessionPage.tsx
@@ -31,7 +31,7 @@ export default function SessionPage(props: SessionPageProps) {
         </Text>
       </Flex>
       <div className="flex flex-row w-full gap-lg">
-        <SessionCalendar session={session} />
+        <SessionCalendar sessionId={session.id} />
         <SmallDirectoryBlock sessionId={session.id} />
       </div>
     </Flex>

--- a/src/app/sessions/[sessionId]/SessionPage.tsx
+++ b/src/app/sessions/[sessionId]/SessionPage.tsx
@@ -31,9 +31,7 @@ export default function SessionPage(props: SessionPageProps) {
         </Text>
       </Flex>
       <div className="flex flex-row w-full gap-lg">
-        <div className="w-full">
-          <SessionCalendar session={session} />
-        </div>
+        <SessionCalendar session={session} />
         <SmallDirectoryBlock sessionId={session.id} />
       </div>
     </Flex>

--- a/src/hooks/sections/useCreateSection.ts
+++ b/src/hooks/sections/useCreateSection.ts
@@ -16,8 +16,8 @@ async function createSection(req: CreateSectionRequest) {
   const { sessionId, ...rest } = req;
   await createSectionDoc(sessionId, {
     name: rest.name,
-    startDate: Timestamp.fromDate(rest.startDate.toDate()),
-    endDate: Timestamp.fromDate(rest.endDate.toDate()),
+    startDate: Timestamp.fromDate(rest.startDate.clone().startOf('day').toDate()),
+    endDate: Timestamp.fromDate(rest.endDate.clone().endOf('day').toDate()),
     type: rest.type,
     publishedAt: null
   })

--- a/src/hooks/sections/useSectionList.ts
+++ b/src/hooks/sections/useSectionList.ts
@@ -9,6 +9,7 @@ export default function useSectionList(sessionId: string, firestoreQueryOptions?
     queryFn: async ({ client }) => {
       const sections = await listSectionDocs(sessionId, firestoreQueryOptions);
       sections.forEach(section => client.setQueryData(['sessions', sessionId, 'sections', section.id], section));
+      return sections;
     }
   });
 }

--- a/src/hooks/sections/useSectionList.ts
+++ b/src/hooks/sections/useSectionList.ts
@@ -1,16 +1,14 @@
 import { listSectionDocs } from "@/data/firestore/sections";
 import { SectionDoc } from "@/data/firestore/types/documents";
 import { FirestoreQueryOptions } from "@/data/firestore/types/queries";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 
-export default function useListSections(sessionId: string, firestoreQueryOptions?: FirestoreQueryOptions<SectionDoc>) {
-  const queryClient = useQueryClient();
-
+export default function useSectionList(sessionId: string, firestoreQueryOptions?: FirestoreQueryOptions<SectionDoc>) {
   return useQuery({
     queryKey: ['sessions', sessionId, 'sections', firestoreQueryOptions],
-    queryFn: async () => {
+    queryFn: async ({ client }) => {
       const sections = await listSectionDocs(sessionId, firestoreQueryOptions);
-      sections.forEach(section => queryClient.setQueryData(['sessions', sessionId, 'sections', section.id], section));
+      sections.forEach(section => client.setQueryData(['sessions', sessionId, 'sections', section.id], section));
     }
   });
 }

--- a/src/hooks/sections/useUpdateSection.ts
+++ b/src/hooks/sections/useUpdateSection.ts
@@ -19,8 +19,8 @@ async function updateSection(req: UpdateSectionRequest) {
     case "COMMON":
       await updateSectionDoc(sessionId, sectionId, {
         name: updates.name,
-        startDate: updates.startDate ? Timestamp.fromDate(updates.startDate.toDate()) : undefined,
-        endDate: updates.endDate ? Timestamp.fromDate(updates.endDate.toDate()) : undefined,
+        startDate: updates.startDate ? Timestamp.fromDate(updates.startDate.clone().startOf('day').toDate()) : undefined,
+        endDate: updates.endDate ? Timestamp.fromDate(updates.endDate.clone().endOf('day').toDate()) : undefined,
         type: "COMMON",
         publishedAt: deleteField()
       });
@@ -30,8 +30,8 @@ async function updateSection(req: UpdateSectionRequest) {
     case "NON-BUNK-JAMBO":
       await updateSectionDoc(sessionId, sectionId, {
         name: updates.name,
-        startDate: updates.startDate ? Timestamp.fromDate(updates.startDate.toDate()) : undefined,
-        endDate: updates.endDate ? Timestamp.fromDate(updates.endDate.toDate()) : undefined,
+        startDate: updates.startDate ? Timestamp.fromDate(updates.startDate.clone().startOf('day').toDate()) : undefined,
+        endDate: updates.endDate ? Timestamp.fromDate(updates.endDate.clone().endOf('day').toDate()) : undefined,
         type: updates.type,
         publishedAt: null
       });
@@ -39,8 +39,8 @@ async function updateSection(req: UpdateSectionRequest) {
     default:
       await updateSectionDoc(sessionId, sectionId, {
         name: updates.name,
-        startDate: updates.startDate ? Timestamp.fromDate(updates.startDate.toDate()) : undefined,
-        endDate: updates.endDate ? Timestamp.fromDate(updates.endDate.toDate()) : undefined,
+        startDate: updates.startDate ? Timestamp.fromDate(updates.startDate.clone().startOf('day').toDate()) : undefined,
+        endDate: updates.endDate ? Timestamp.fromDate(updates.endDate.clone().endOf('day').toDate()) : undefined,
       });
   }
 


### PR DESCRIPTION
- Added sections as events to SessionCalendar
  - Badges are color-coded by the section type
  - Clicking on a section event redirects the user to the section's page
    - Only applies to scheduling sections, clicking a common section's event does nothing since they have no scheduling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed event creation to properly set end times at end-of-day for single-day and drag selections, improving consistency across time-based operations.
  * Improved date normalization for section creation and updates to ensure dates align to day boundaries.

* **New Features**
  * Events now navigate to their detail page when clicked for quick access to event information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hack4Impact-UMD/camp-starfish/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->