### PR TITLE
feat(users): create UploadUsersCsvModal

### DIFF
--- a/functions/src/features/userCSVParsing.ts
+++ b/functions/src/features/userCSVParsing.ts
@@ -1,6 +1,6 @@
 import { Camper, Parent, Role, UnregisteredCamper, UnregisteredEmployee, UnregisteredParent } from "@/types/users/userTypes";
 import { HttpsError, onCall } from "firebase-functions/https"
-import { ParseFamilyCSVResponse } from "@/features/userManagement/parseFamilyCSV";
+import { ParsedFamilyCsvData } from "@/features/userManagement/types";
 import { adminDb } from "../config/firebaseAdminConfig";
 import { batchGetUserDocs, createUserDoc, updateUserDoc } from "../data/firestore/users";
 import partition from "@/utils/data/partition";
@@ -12,7 +12,7 @@ export const handleFamilyCSVUpload = onCall(async (req) => {
     throw new HttpsError("permission-denied", "You do not have permission to create new users.");
   }
 
-  const { campers, parents } = req.data as ParseFamilyCSVResponse;
+  const { campers, parents } = req.data as ParsedFamilyCsvData;
 
   await adminDb.runTransaction(async (transaction) => {
     const allIds: number[] = [...Object.keys(campers), ...Object.keys(parents)].map(id => parseInt(id));

--- a/functions/src/features/userCSVParsing.ts
+++ b/functions/src/features/userCSVParsing.ts
@@ -55,7 +55,7 @@ export const handleFamilyCSVUpload = onCall(async (req) => {
 
 export const handleEmployeeCSVUpload = onCall(async (req) => {
   const role: Role | undefined = req.auth?.token.role;
-  if (!role || role !== "ADMIN") {
+  if (role !== "ADMIN") {
     throw new HttpsError("permission-denied", "You do not have permission to create new users.");
   }
 

--- a/src/components/UploadAlbumItemsModal/UploadAlbumItemsModal.tsx
+++ b/src/components/UploadAlbumItemsModal/UploadAlbumItemsModal.tsx
@@ -111,11 +111,11 @@ export function UploadAlbumItemsModal(props: UploadAlbumItemsModalProps) {
         onDrop={onDrop}
         onReject={onReject}
       >
-        <Text className="text-center">{`Supported file types: ${acceptedMimeTypes.map((mimeType) => extension(mimeType)).join(", ")} (Max ${maxFileSizeMB}MB)`}</Text>
+        <Text>{`Supported file types: ${acceptedMimeTypes.map((mimeType) => extension(mimeType)).join(", ")} (Max ${maxFileSizeMB}MB)`}</Text>
         <MdOutlineFileUpload className="text-neutral-4" size={50} />
-        <Text className="text-center">{"Drag and drop files"}</Text>
-        <Text className="text-center">{"OR"}</Text>
-        <Text className="text-center">{"Select from device"}</Text>
+        <Text>{"Drag and drop files"}</Text>
+        <Text>{"OR"}</Text>
+        <Text>{"Select from device"}</Text>
       </Dropzone>
       <ScrollArea.Autosize
         classNames={{

--- a/src/components/UploadAlbumItemsModal/UploadAlbumItemsModal.tsx
+++ b/src/components/UploadAlbumItemsModal/UploadAlbumItemsModal.tsx
@@ -106,10 +106,6 @@ export function UploadAlbumItemsModal(props: UploadAlbumItemsModalProps) {
   return (
     <>
       <Dropzone
-        classNames={{
-          inner:
-            "flex flex-col justify-center items-center border-4 border-dashed border-orange-5 rounded-lg my-2 p-2",
-        }}
         accept={acceptedMimeTypes}
         maxSize={MBToBytes(maxFileSizeMB)}
         onDrop={onDrop}

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -162,7 +162,10 @@ export function UploadUsersCsvModal() {
       )}
       {parsedData && (
         <ScrollArea.Autosize className="max-h-[40vh] w-full">
-          <Title order={6}>The following users were found. Please ensure they are correct before uploading.</Title>
+          <Title order={6}>
+            The following users were found. Please ensure they are correct
+            before uploading.
+          </Title>
           {isParsedFamilyCsvData(parsedData) ? (
             <>
               <Text>Campers</Text>
@@ -171,7 +174,9 @@ export function UploadUsersCsvModal() {
                   const camperId = parseInt(camperIdStr);
                   const camper = parsedData.campers[camperId];
                   return (
-                    <Badge key={camperId}>{getFullName(camper.name)}</Badge>
+                    <div className="flex flex-row items-center w-full bg-neutral-3 rounded-sm p-xs">
+                      <Text key={camperId}>{getFullName(camper.name)}</Text>
+                    </div>
                   );
                 })}
               </div>
@@ -181,7 +186,11 @@ export function UploadUsersCsvModal() {
                   const parentId = parseInt(parentIdStr);
                   const parent = parsedData.parents[parentId];
                   return (
-                    <Badge key={parentId}>{getFullName(parent.name)}</Badge>
+                    <div className="flex flex-row items-center w-full bg-neutral-3 rounded-sm p-xs">
+                      <Text key={parentId}>
+                        {getFullName(parent.name)} ({parent.email})
+                      </Text>
+                    </div>
                   );
                 })}
               </div>

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -1,4 +1,6 @@
 import {
+  isParsedEmployeeCsvData,
+  isParsedFamilyCsvData,
   ParsedUsersCsvData,
   UsersCsvType,
   usersCsvTypes,
@@ -42,6 +44,16 @@ export function UploadUsersCsvModal() {
     parseCsvFile(csvType, csvFile);
   };
 
+  const handleSubmit = () => {
+    if (!parsedData) {
+      return;
+    } else if (csvType === "FAMILY" && isParsedFamilyCsvData(parsedData)) {
+      processFamilyCsvMutation.mutate({ parsedFamilyCsvData: parsedData }, { onSuccess: () => modals.closeAll() });
+    } else if (csvType === "EMPLOYEE" && isParsedEmployeeCsvData(parsedData)) {
+      processEmployeeCsvMutation.mutate({ parsedEmployeeCsvData: parsedData }, { onSuccess: () => modals.closeAll() });
+    }
+  }
+
   return (
     <div className="flex flex-col gap-md">
       <div>
@@ -79,7 +91,9 @@ export function UploadUsersCsvModal() {
       </Radio.Group>
       <Button
         classNames={{ root: "self-center" }}
+        onClick={handleSubmit}
         disabled={!csvFile || !csvType}
+        loading={processFamilyCsvMutation.isPending || processEmployeeCsvMutation.isPending}
       >
         Create Users
       </Button>

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -15,6 +15,7 @@ import { Dropzone, DropzoneProps } from "@mantine/dropzone";
 import { modals } from "@mantine/modals";
 import { useState } from "react";
 import { MdOutlineFileUpload } from "react-icons/md";
+import { EmployeeRole } from "@/types/users/userTypes";
 
 const usersCsvTypeToLabel: Record<UsersCsvType, string> = {
   FAMILY: "Families (Campers + Parents)",
@@ -24,6 +25,7 @@ const usersCsvTypeToLabel: Record<UsersCsvType, string> = {
 export function UploadUsersCsvModal() {
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [csvType, setCsvType] = useState<UsersCsvType>("FAMILY");
+  const [roleSelects, setRoleSelects] = useState<{ [employeeId: number]: EmployeeRole; } | null>(null);
 
   const parseFamilyCsvMutation = useParseFamilyCsv();
   const parseEmployeeCsvMutation = useParseEmployeeCsv();
@@ -33,14 +35,18 @@ export function UploadUsersCsvModal() {
   const processEmployeeCsvMutation = useProcessEmployeeCSV();
 
   const parseCsvFile = (usersCsvType: UsersCsvType, csvFile: File) => {
-    (usersCsvType === "FAMILY"
-      ? parseFamilyCsvMutation
-      : parseEmployeeCsvMutation
-    ).mutate({ csvFile });
-    (usersCsvType === "FAMILY"
-      ? parseEmployeeCsvMutation
-      : parseFamilyCsvMutation
-    ).reset();
+    if (usersCsvType === "FAMILY") {
+      parseFamilyCsvMutation.mutate({ csvFile });
+      parseEmployeeCsvMutation.reset();
+      setRoleSelects(null);
+    } else {
+      parseEmployeeCsvMutation.mutate({ csvFile }, { onSuccess: (data) => {
+        const roleSelects: { [employeeId: number]: EmployeeRole; } = {};
+        data.forEach(employee => roleSelects[employee.id] = "STAFF");
+        setRoleSelects(roleSelects);
+      }});
+      parseFamilyCsvMutation.reset();
+    }
     processFamilyCsvMutation.reset();
     processEmployeeCsvMutation.reset();
   };

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -11,7 +11,6 @@ import useProcessEmployeeCSV from "@/features/userManagement/useProcessEmployeeC
 import useProcessFamilyCSV from "@/features/userManagement/useProcessFamilyCSV";
 import { MBToBytes } from "@/utils/fileUtils";
 import {
-  Badge,
   Button,
   Loader,
   Radio,
@@ -174,8 +173,8 @@ export function UploadUsersCsvModal() {
                   const camperId = parseInt(camperIdStr);
                   const camper = parsedData.campers[camperId];
                   return (
-                    <div className="flex flex-row items-center w-full bg-neutral-3 rounded-sm p-xs">
-                      <Text key={camperId}>{getFullName(camper.name)}</Text>
+                    <div key={camperId} className="flex flex-row items-center w-full bg-neutral-3 rounded-sm p-xs">
+                      <Text>{getFullName(camper.name)}</Text>
                     </div>
                   );
                 })}
@@ -186,8 +185,8 @@ export function UploadUsersCsvModal() {
                   const parentId = parseInt(parentIdStr);
                   const parent = parsedData.parents[parentId];
                   return (
-                    <div className="flex flex-row items-center w-full bg-neutral-3 rounded-sm p-xs">
-                      <Text key={parentId}>
+                    <div key={parentId} className="flex flex-row items-center w-full bg-neutral-3 rounded-sm p-xs">
+                      <Text>
                         {getFullName(parent.name)} ({parent.email})
                       </Text>
                     </div>
@@ -200,8 +199,8 @@ export function UploadUsersCsvModal() {
               <Text>Employees</Text>
               {parsedData.map((employee) => {
                 return (
-                  <div className="flex flex-row justify-between items-center bg-neutral-3 rounded-sm p-xs">
-                    <Text key={employee.id}>{getFullName(employee.name)}</Text>
+                  <div key={employee.id} className="flex flex-row justify-between items-center bg-neutral-3 rounded-sm p-xs">
+                    <Text >{getFullName(employee.name)}</Text>
                     <Select
                       data={["ADMIN", "STAFF", "PHOTOGRAPHER"]}
                       value={roleSelects![employee.id]}

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -71,6 +71,28 @@ export function UploadUsersCsvModal() {
 
   return (
     <div className="flex flex-col gap-md items-center">
+      <Radio.Group
+        classNames={{ root: "w-full" }}
+        value={csvType}
+        label={"Type of Users"}
+      >
+        <div className="flex flex-col gap-xs">
+          {usersCsvTypes.map((type) => (
+            <Radio
+              key={type}
+              value={type}
+              label={usersCsvTypeToLabel[type]}
+              onChange={() => {
+                setCsvType(type);
+                if (csvFile) {
+                  parseCsvFile(type, csvFile);
+                }
+              }}
+              required
+            />
+          ))}
+        </div>
+      </Radio.Group>
       <Dropzone
         onDrop={handleFileSelect}
         maxFiles={1}
@@ -98,28 +120,6 @@ export function UploadUsersCsvModal() {
           {parseEmployeeCsvMutation.error.message}
         </Text>
       )}
-      <Radio.Group
-        classNames={{ root: "w-full" }}
-        value={csvType}
-        label={"Type of Users"}
-      >
-        <div className="flex flex-col gap-xs">
-          {usersCsvTypes.map((type) => (
-            <Radio
-              key={type}
-              value={type}
-              label={usersCsvTypeToLabel[type]}
-              onChange={() => {
-                setCsvType(type);
-                if (csvFile) {
-                  parseCsvFile(type, csvFile);
-                }
-              }}
-              required
-            />
-          ))}
-        </div>
-      </Radio.Group>
       <Button
         classNames={{ root: "self-center" }}
         onClick={handleSubmit}

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -71,15 +71,19 @@ export function UploadUsersCsvModal() {
   const handleSubmit = () => {
     if (!parsedData) {
       return;
-    } else if (csvType === "FAMILY" && isParsedFamilyCsvData(parsedData)) {
+    } else if (csvType === "FAMILY" && isParsedFamilyCsvData(parsedData) && !roleSelects) {
       processFamilyCsvMutation.mutate(
         { parsedFamilyCsvData: parsedData },
         { onSuccess: () => modals.closeAll() },
       );
       processEmployeeCsvMutation.reset();
-    } else if (csvType === "EMPLOYEE" && isParsedEmployeeCsvData(parsedData)) {
+    } else if (csvType === "EMPLOYEE" && isParsedEmployeeCsvData(parsedData) && roleSelects) {
+      const employeeData = parsedData.map(employee => ({
+        ...employee,
+        role: roleSelects[employee.id]
+      }))
       processEmployeeCsvMutation.mutate(
-        { parsedEmployeeCsvData: parsedData },
+        { parsedEmployeeCsvData: employeeData },
         { onSuccess: () => modals.closeAll() },
       );
       processFamilyCsvMutation.reset();

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -34,6 +34,7 @@ export function UploadUsersCsvModal() {
             value={type}
             label={toNormalCase(type)}
             onChange={() => setCsvType(type)}
+            required
           />
         ))}
         </div>

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -1,5 +1,5 @@
 import { toNormalCase } from "@/utils/stringUtils";
-import { Radio, Text } from "@mantine/core";
+import { Button, Radio, Text } from "@mantine/core";
 import { Dropzone } from "@mantine/dropzone";
 import { modals } from "@mantine/modals";
 import { useState } from "react";
@@ -14,7 +14,7 @@ export function UploadUsersCsvModal() {
   const [csvType, setCsvType] = useState<UsersCsvType | null>(null);
 
   return (
-    <>
+    <div className="flex flex-col gap-md">
       <Dropzone
         onDrop={(files) => setCsvFile(files[0])}
         maxFiles={1}
@@ -23,7 +23,10 @@ export function UploadUsersCsvModal() {
         <MdOutlineFileUpload size={60} />
         <Text>Upload a users CSV file exported from Campminder here</Text>
       </Dropzone>
-      <Radio.Group>
+      <Radio.Group
+        value={csvType}
+        label={"Select the type of CSV file you are uploading"}
+      >
         {usersCsvTypes.map((type) => (
           <Radio
             key={type}
@@ -33,7 +36,8 @@ export function UploadUsersCsvModal() {
           />
         ))}
       </Radio.Group>
-    </>
+      <Button classNames={{ root: "self-center" }}>Create Users</Button>
+    </div>
   );
 }
 

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -10,7 +10,7 @@ import useParseEmployeeCsv from "@/features/userManagement/useParseEmployeeCsv";
 import useProcessEmployeeCSV from "@/features/userManagement/useProcessEmployeeCSV";
 import useProcessFamilyCSV from "@/features/userManagement/useProcessFamilyCSV";
 import { MBToBytes } from "@/utils/fileUtils";
-import { Badge, Button, Loader, Radio, Text, Title } from "@mantine/core";
+import { Badge, Button, Loader, Radio, Select, Text, Title } from "@mantine/core";
 import { Dropzone, DropzoneProps } from "@mantine/dropzone";
 import { modals } from "@mantine/modals";
 import { useState } from "react";
@@ -156,8 +156,8 @@ export function UploadUsersCsvModal() {
         ) : (
           <>
             <Title order={6}>Employees</Title>
-            {parsedData.map((employee) => {
-              return <Badge key={employee.id}>{getFullName(employee.name)}</Badge>;
+            {parsedData.map((employee, i) => {
+              return <><Badge key={employee.id}>{getFullName(employee.name)}</Badge><Select data={["STAFF", "ADMIN", "PHOTOGRAPHER"]} value={roleSelects![i]} onChange={(role) => setRoleSelects(prev => prev ? ({ ...prev, [employee.id]: role }) : null)}/></>;
             })}
           </>
         ))}

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -1,5 +1,6 @@
 import useProcessEmployeeCSV from "@/features/userManagement/useProcessEmployeeCSV";
 import useProcessFamilyCSV from "@/features/userManagement/useProcessFamilyCSV";
+import { MBToBytes } from "@/utils/fileUtils";
 import { Button, Radio, Text } from "@mantine/core";
 import { Dropzone } from "@mantine/dropzone";
 import { modals } from "@mantine/modals";
@@ -52,12 +53,13 @@ export function UploadUsersCsvModal() {
           onDrop={(files) => setCsvFile(files[0])}
           maxFiles={1}
           accept={["text/csv"]}
+          maxSize={MBToBytes(5)}
         >
           <MdOutlineFileUpload size={60} />
           <Text>
             {csvFile
               ? `Selected File: "${csvFile.name}"`
-              : "Upload a users CSV file exported from Campminder here"}
+              : "Upload a users CSV file exported from Campminder here (Max: 5MB)"}
           </Text>
         </Dropzone>
         {error && (

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -1,0 +1,45 @@
+import { toNormalCase } from "@/utils/stringUtils";
+import { Radio, Text } from "@mantine/core";
+import { Dropzone } from "@mantine/dropzone";
+import { modals } from "@mantine/modals";
+import { useState } from "react";
+import { MdOutlineFileUpload } from "react-icons/md";
+
+type UsersCsvType = "FAMILY" | "EMPLOYEE";
+
+const usersCsvTypes: UsersCsvType[] = ["FAMILY", "EMPLOYEE"];
+
+export function UploadUsersCsvModal() {
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [csvType, setCsvType] = useState<UsersCsvType | null>(null);
+
+  return (
+    <>
+      <Dropzone
+        onDrop={(files) => setCsvFile(files[0])}
+        maxFiles={1}
+        accept={["text/csv"]}
+      >
+        <MdOutlineFileUpload size={60} />
+        <Text>Upload a users CSV file exported from Campminder here</Text>
+      </Dropzone>
+      <Radio.Group>
+        {usersCsvTypes.map((type) => (
+          <Radio
+            key={type}
+            value={type}
+            label={toNormalCase(type)}
+            onChange={() => setCsvType(type)}
+          />
+        ))}
+      </Radio.Group>
+    </>
+  );
+}
+
+export default function openUploadUsersCsvModal() {
+  modals.open({
+    title: "Upload Users CSV",
+    children: <UploadUsersCsvModal />,
+  });
+}

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -193,7 +193,7 @@ export function UploadUsersCsvModal() {
                   <div className="flex flex-row justify-between items-center bg-neutral-3 rounded-sm p-xs">
                     <Text key={employee.id}>{getFullName(employee.name)}</Text>
                     <Select
-                      data={["STAFF", "ADMIN", "PHOTOGRAPHER"]}
+                      data={["ADMIN", "STAFF", "PHOTOGRAPHER"]}
                       value={roleSelects![employee.id]}
                       defaultValue="STAFF"
                       onChange={(role) =>

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -1,6 +1,5 @@
 import useProcessEmployeeCSV from "@/features/userManagement/useProcessEmployeeCSV";
 import useProcessFamilyCSV from "@/features/userManagement/useProcessFamilyCSV";
-import { toNormalCase } from "@/utils/stringUtils";
 import { Button, Radio, Text } from "@mantine/core";
 import { Dropzone } from "@mantine/dropzone";
 import { modals } from "@mantine/modals";
@@ -10,6 +9,11 @@ import { MdOutlineFileUpload } from "react-icons/md";
 type UsersCsvType = "FAMILY" | "EMPLOYEE";
 
 const usersCsvTypes: UsersCsvType[] = ["FAMILY", "EMPLOYEE"];
+
+const usersCsvTypeToLabel: Record<UsersCsvType, string> = {
+  FAMILY: "Families (Campers + Parents)",
+  EMPLOYEE: "Employees (Admins + Staff + Photographers)",
+};
 
 export function UploadUsersCsvModal() {
   const [csvFile, setCsvFile] = useState<File | null>(null);
@@ -50,14 +54,14 @@ export function UploadUsersCsvModal() {
       </Dropzone>
       <Radio.Group
         value={csvType}
-        label={"Select the type of CSV file you are uploading"}
+        label={"Type of Users"}
       >
         <div className="flex flex-col gap-xs">
           {usersCsvTypes.map((type) => (
             <Radio
               key={type}
               value={type}
-              label={toNormalCase(type)}
+              label={usersCsvTypeToLabel[type]}
               onChange={() => setCsvType(type)}
               required
             />

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -10,12 +10,11 @@ import useParseEmployeeCsv from "@/features/userManagement/useParseEmployeeCsv";
 import useProcessEmployeeCSV from "@/features/userManagement/useProcessEmployeeCSV";
 import useProcessFamilyCSV from "@/features/userManagement/useProcessFamilyCSV";
 import { MBToBytes } from "@/utils/fileUtils";
-import { Button, Radio, Text } from "@mantine/core";
+import { Button, Loader, Radio, Text } from "@mantine/core";
 import { Dropzone, DropzoneProps } from "@mantine/dropzone";
 import { modals } from "@mantine/modals";
 import { useState } from "react";
 import { MdOutlineFileUpload } from "react-icons/md";
-import { parse } from "path";
 
 const usersCsvTypeToLabel: Record<UsersCsvType, string> = {
   FAMILY: "Families (Campers + Parents)",
@@ -33,11 +32,16 @@ export function UploadUsersCsvModal() {
   const processFamilyCsvMutation = useProcessFamilyCSV();
   const processEmployeeCsvMutation = useProcessEmployeeCSV();
 
-  const parseCsvFile = (usersCsvType: UsersCsvType, csvFile: File) =>
+  const parseCsvFile = (usersCsvType: UsersCsvType, csvFile: File) => {
     (usersCsvType === "FAMILY"
       ? parseFamilyCsvMutation
       : parseEmployeeCsvMutation
     ).mutate({ csvFile }, { onSuccess: (data) => setParsedData(data) });
+    (usersCsvType === "FAMILY"
+      ? parseEmployeeCsvMutation
+      : parseFamilyCsvMutation
+    ).reset();
+  };
 
   const handleFileSelect: DropzoneProps["onDrop"] = (files) => {
     const csvFile = files[0];
@@ -62,24 +66,39 @@ export function UploadUsersCsvModal() {
   };
 
   return (
-    <div className="flex flex-col gap-md">
-      <div>
-        <Dropzone
-          onDrop={handleFileSelect}
-          maxFiles={1}
-          accept={["text/csv"]}
-          maxSize={MBToBytes(5)}
-        >
-          <MdOutlineFileUpload size={60} />
-          <Text>
-            {csvFile
-              ? `Selected File: "${csvFile.name}"`
-              : "Upload a users CSV file exported from Campminder here (Max: 5MB)"}
-          </Text>
-        </Dropzone>
-        {}
-      </div>
-      <Radio.Group value={csvType} label={"Type of Users"}>
+    <div className="flex flex-col gap-md items-center">
+      <Dropzone
+        onDrop={handleFileSelect}
+        maxFiles={1}
+        accept={["text/csv"]}
+        maxSize={MBToBytes(5)}
+      >
+        <MdOutlineFileUpload size={60} />
+        <Text>
+          {csvFile
+            ? `Selected File: "${csvFile.name}"`
+            : "Upload a users CSV file exported from Campminder here (Max: 5MB)"}
+        </Text>
+      </Dropzone>
+      {(parseFamilyCsvMutation.isPending ||
+        parseEmployeeCsvMutation.isPending) && (
+        <Loader className="self-center" size="xs" />
+      )}
+      {parseFamilyCsvMutation.error && (
+        <Text className="text-error text-sm text-center">
+          {parseFamilyCsvMutation.error.message}
+        </Text>
+      )}
+      {parseEmployeeCsvMutation.error && (
+        <Text className="text-error text-sm text-center">
+          {parseEmployeeCsvMutation.error.message}
+        </Text>
+      )}
+      <Radio.Group
+        classNames={{ root: "w-full" }}
+        value={csvType}
+        label={"Type of Users"}
+      >
         <div className="flex flex-col gap-xs">
           {usersCsvTypes.map((type) => (
             <Radio

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -1,8 +1,15 @@
-import { UsersCsvType, usersCsvTypes } from "@/features/userManagement/types";
-import useProcessUsersCsv from "@/features/userManagement/useProcessUsersCsv";
+import {
+  ParsedUsersCsvData,
+  UsersCsvType,
+  usersCsvTypes,
+} from "@/features/userManagement/types";
+import useParseFamilyCsv from "@/features/userManagement/useParseFamilyCsv";
+import useParseEmployeeCsv from "@/features/userManagement/useParseEmployeeCsv";
+import useProcessEmployeeCSV from "@/features/userManagement/useProcessEmployeeCSV";
+import useProcessFamilyCSV from "@/features/userManagement/useProcessFamilyCSV";
 import { MBToBytes } from "@/utils/fileUtils";
 import { Button, Radio, Text } from "@mantine/core";
-import { Dropzone } from "@mantine/dropzone";
+import { Dropzone, DropzoneProps } from "@mantine/dropzone";
 import { modals } from "@mantine/modals";
 import { useState } from "react";
 import { MdOutlineFileUpload } from "react-icons/md";
@@ -15,24 +22,31 @@ const usersCsvTypeToLabel: Record<UsersCsvType, string> = {
 export function UploadUsersCsvModal() {
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [csvType, setCsvType] = useState<UsersCsvType>("FAMILY");
+  const [parsedData, setParsedData] = useState<ParsedUsersCsvData | null>(null);
 
-  const processUsersCsvMutation = useProcessUsersCsv(csvType);
+  const parseFamilyCsvMutation = useParseFamilyCsv();
+  const parseEmployeeCsvMutation = useParseEmployeeCsv();
 
-  const handleSubmit = async () => {
-    if (!csvFile) {
-      return;
-    }
-    processUsersCsvMutation.mutate(
-      { csvFile },
-      { onSuccess: () => modals.closeAll() },
-    );
+  const processFamilyCsvMutation = useProcessFamilyCSV();
+  const processEmployeeCsvMutation = useProcessEmployeeCSV();
+
+  const parseCsvFile = (usersCsvType: UsersCsvType, csvFile: File) =>
+    (usersCsvType === "FAMILY"
+      ? parseFamilyCsvMutation
+      : parseEmployeeCsvMutation
+    ).mutate({ csvFile }, { onSuccess: (data) => setParsedData(data) });
+
+  const handleFileSelect: DropzoneProps["onDrop"] = (files) => {
+    const csvFile = files[0];
+    setCsvFile(csvFile);
+    parseCsvFile(csvType, csvFile);
   };
 
   return (
     <div className="flex flex-col gap-md">
       <div>
         <Dropzone
-          onDrop={(files) => setCsvFile(files[0])}
+          onDrop={handleFileSelect}
           maxFiles={1}
           accept={["text/csv"]}
           maxSize={MBToBytes(5)}
@@ -44,11 +58,6 @@ export function UploadUsersCsvModal() {
               : "Upload a users CSV file exported from Campminder here (Max: 5MB)"}
           </Text>
         </Dropzone>
-        {processUsersCsvMutation.error && (
-          <Text className="text-error text-sm text-center">
-            {processUsersCsvMutation.error.message}
-          </Text>
-        )}
       </div>
       <Radio.Group value={csvType} label={"Type of Users"}>
         <div className="flex flex-col gap-xs">
@@ -57,7 +66,12 @@ export function UploadUsersCsvModal() {
               key={type}
               value={type}
               label={usersCsvTypeToLabel[type]}
-              onChange={() => setCsvType(type)}
+              onChange={() => {
+                setCsvType(type);
+                if (csvFile) {
+                  parseCsvFile(type, csvFile);
+                }
+              }}
               required
             />
           ))}
@@ -65,9 +79,7 @@ export function UploadUsersCsvModal() {
       </Radio.Group>
       <Button
         classNames={{ root: "self-center" }}
-        onClick={handleSubmit}
         disabled={!csvFile || !csvType}
-        loading={processUsersCsvMutation.isPending}
       >
         Create Users
       </Button>

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -160,46 +160,55 @@ export function UploadUsersCsvModal() {
           {parseEmployeeCsvMutation.error.message}
         </Text>
       )}
-      {parsedData && <ScrollArea.Autosize className="max-h-[40vh] w-full">
-        {isParsedFamilyCsvData(parsedData) ? (
-          <>
-            <Title order={6}>Campers</Title>
-            {Object.keys(parsedData.campers).map((camperIdStr) => {
-              const camperId = parseInt(camperIdStr);
-              const camper = parsedData.campers[camperId];
-              return <Badge key={camperId}>{getFullName(camper.name)}</Badge>;
-            })}
-            <Title order={6}>Parents</Title>
-            {Object.keys(parsedData.parents).map((parentIdStr) => {
-              const parentId = parseInt(parentIdStr);
-              const parent = parsedData.parents[parentId];
-              return <Badge key={parentId}>{getFullName(parent.name)}</Badge>;
-            })}
-          </>
-        ) : (
-          <>
-            <Title order={6}>Employees</Title>
-            {parsedData.map((employee) => {
-              return (
-                <>
-                  <Badge key={employee.id}>{getFullName(employee.name)}</Badge>
-                  <Select
-                    data={["STAFF", "ADMIN", "PHOTOGRAPHER"]}
-                    value={roleSelects![employee.id]}
-                    defaultValue="STAFF"
-                    onChange={(role) =>
-                      setRoleSelects((prev) =>
-                        prev ? { ...prev, [employee.id]: role } : null,
-                      )
-                    }
-                  />
-                </>
-              );
-            })}
-          </>
-        )}
-      </ScrollArea.Autosize>
-        }
+      {parsedData && (
+        <ScrollArea.Autosize className="max-h-[40vh] w-full">
+          {isParsedFamilyCsvData(parsedData) ? (
+            <>
+              <Title order={6}>Campers</Title>
+              <div className="flex flex-row flex-wrap gap-xs">
+                {Object.keys(parsedData.campers).map((camperIdStr) => {
+                  const camperId = parseInt(camperIdStr);
+                  const camper = parsedData.campers[camperId];
+                  return (
+                    <Badge key={camperId}>{getFullName(camper.name)}</Badge>
+                  );
+                })}
+              </div>
+              <Title order={6}>Parents</Title>
+              <div className="flex flex-row flex-wrap gap-xs">
+                {Object.keys(parsedData.parents).map((parentIdStr) => {
+                  const parentId = parseInt(parentIdStr);
+                  const parent = parsedData.parents[parentId];
+                  return (
+                    <Badge key={parentId}>{getFullName(parent.name)}</Badge>
+                  );
+                })}
+              </div>
+            </>
+          ) : (
+            <div className="flex flex-col gap-xs">
+              <Title order={6}>Employees</Title>
+              {parsedData.map((employee) => {
+                return (
+                  <div className="flex flex-row justify-between items-center bg-neutral-3 rounded-sm p-xs">
+                    <Text key={employee.id}>{getFullName(employee.name)}</Text>
+                    <Select
+                      data={["STAFF", "ADMIN", "PHOTOGRAPHER"]}
+                      value={roleSelects![employee.id]}
+                      defaultValue="STAFF"
+                      onChange={(role) =>
+                        setRoleSelects((prev) =>
+                          prev ? { ...prev, [employee.id]: role! } : null,
+                        )
+                      }
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </ScrollArea.Autosize>
+      )}
       <Button
         classNames={{ root: "self-center" }}
         onClick={handleSubmit}

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -161,7 +161,21 @@ export function UploadUsersCsvModal() {
           <>
             <Title order={6}>Employees</Title>
             {parsedData.map((employee, i) => {
-              return <><Badge key={employee.id}>{getFullName(employee.name)}</Badge><Select data={["STAFF", "ADMIN", "PHOTOGRAPHER"]} value={roleSelects![employee.id]} onChange={(role) => setRoleSelects(prev => prev ? ({ ...prev, [employee.id]: role }) : null)}/></>;
+              return (
+                <>
+                  <Badge key={employee.id}>{getFullName(employee.name)}</Badge>
+                  <Select
+                    data={["STAFF", "ADMIN", "PHOTOGRAPHER"]}
+                    value={roleSelects![employee.id]}
+                    defaultValue="STAFF"
+                    onChange={(role) =>
+                      setRoleSelects((prev) =>
+                        prev ? { ...prev, [employee.id]: role } : null,
+                      )
+                    }
+                  />
+                </>
+              );
             })}
           </>
         ))}

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -26,7 +26,6 @@ export function UploadUsersCsvModal() {
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [csvType, setCsvType] = useState<UsersCsvType>("FAMILY");
   const [parsedData, setParsedData] = useState<ParsedUsersCsvData | null>(null);
-  const [showParseError, setShowError] = useState<boolean>(false);
 
   const parseFamilyCsvMutation = useParseFamilyCsv();
   const parseEmployeeCsvMutation = useParseEmployeeCsv();

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -21,7 +21,7 @@ export function UploadUsersCsvModal() {
         accept={["text/csv"]}
       >
         <MdOutlineFileUpload size={60} />
-        <Text>Upload a users CSV file exported from Campminder here</Text>
+        <Text>{csvFile ? `Selected File: "${csvFile.name}"` : "Upload a users CSV file exported from Campminder here"}</Text>
       </Dropzone>
       <Radio.Group
         value={csvType}
@@ -38,7 +38,7 @@ export function UploadUsersCsvModal() {
         ))}
         </div>
       </Radio.Group>
-      <Button classNames={{ root: "self-center" }}>Create Users</Button>
+      <Button classNames={{ root: "self-center" }} disabled={!csvFile || !csvType}>Create Users</Button>
     </div>
   );
 }

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -10,12 +10,13 @@ import useParseEmployeeCsv from "@/features/userManagement/useParseEmployeeCsv";
 import useProcessEmployeeCSV from "@/features/userManagement/useProcessEmployeeCSV";
 import useProcessFamilyCSV from "@/features/userManagement/useProcessFamilyCSV";
 import { MBToBytes } from "@/utils/fileUtils";
-import { Button, Loader, Radio, Text } from "@mantine/core";
+import { Badge, Button, Loader, Radio, Text, Title } from "@mantine/core";
 import { Dropzone, DropzoneProps } from "@mantine/dropzone";
 import { modals } from "@mantine/modals";
 import { useState } from "react";
 import { MdOutlineFileUpload } from "react-icons/md";
 import { EmployeeRole } from "@/types/users/userTypes";
+import { getFullName } from "@/types/users/userUtils";
 
 const usersCsvTypeToLabel: Record<UsersCsvType, string> = {
   FAMILY: "Families (Campers + Parents)",
@@ -25,11 +26,16 @@ const usersCsvTypeToLabel: Record<UsersCsvType, string> = {
 export function UploadUsersCsvModal() {
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [csvType, setCsvType] = useState<UsersCsvType>("FAMILY");
-  const [roleSelects, setRoleSelects] = useState<{ [employeeId: number]: EmployeeRole; } | null>(null);
+  const [roleSelects, setRoleSelects] = useState<{
+    [employeeId: number]: EmployeeRole;
+  } | null>(null);
 
   const parseFamilyCsvMutation = useParseFamilyCsv();
   const parseEmployeeCsvMutation = useParseEmployeeCsv();
-  const parsedData: ParsedUsersCsvData | undefined = csvType === "FAMILY" ? parseFamilyCsvMutation.data : parseEmployeeCsvMutation.data;
+  const parsedData: ParsedUsersCsvData | undefined =
+    csvType === "FAMILY"
+      ? parseFamilyCsvMutation.data
+      : parseEmployeeCsvMutation.data;
 
   const processFamilyCsvMutation = useProcessFamilyCSV();
   const processEmployeeCsvMutation = useProcessEmployeeCSV();
@@ -40,11 +46,16 @@ export function UploadUsersCsvModal() {
       parseEmployeeCsvMutation.reset();
       setRoleSelects(null);
     } else {
-      parseEmployeeCsvMutation.mutate({ csvFile }, { onSuccess: (data) => {
-        const roleSelects: { [employeeId: number]: EmployeeRole; } = {};
-        data.forEach(employee => roleSelects[employee.id] = "STAFF");
-        setRoleSelects(roleSelects);
-      }});
+      parseEmployeeCsvMutation.mutate(
+        { csvFile },
+        {
+          onSuccess: (data) => {
+            const roleSelects: { [employeeId: number]: EmployeeRole } = {};
+            data.forEach((employee) => (roleSelects[employee.id] = "STAFF"));
+            setRoleSelects(roleSelects);
+          },
+        },
+      );
       parseFamilyCsvMutation.reset();
     }
     processFamilyCsvMutation.reset();
@@ -126,6 +137,30 @@ export function UploadUsersCsvModal() {
           {parseEmployeeCsvMutation.error.message}
         </Text>
       )}
+      {parsedData &&
+        (isParsedFamilyCsvData(parsedData) ? (
+          <>
+            <Title order={6}>Campers</Title>
+            {Object.keys(parsedData.campers).map((camperIdStr) => {
+              const camperId = parseInt(camperIdStr);
+              const camper = parsedData.campers[camperId];
+              return <Badge key={camperId}>{getFullName(camper.name)}</Badge>;
+            })}
+            <Title order={6}>Parents</Title>
+            {Object.keys(parsedData.parents).map((parentIdStr) => {
+              const parentId = parseInt(parentIdStr);
+              const parent = parsedData.parents[parentId];
+              return <Badge key={parentId}>{getFullName(parent.name)}</Badge>;
+            })}
+          </>
+        ) : (
+          <>
+            <Title order={6}>Employees</Title>
+            {parsedData.map((employee) => {
+              return <Badge key={employee.id}>{getFullName(employee.name)}</Badge>;
+            })}
+          </>
+        ))}
       <Button
         classNames={{ root: "self-center" }}
         onClick={handleSubmit}

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -162,9 +162,10 @@ export function UploadUsersCsvModal() {
       )}
       {parsedData && (
         <ScrollArea.Autosize className="max-h-[40vh] w-full">
+          <Title order={6}>The following users were found. Please ensure they are correct before uploading.</Title>
           {isParsedFamilyCsvData(parsedData) ? (
             <>
-              <Title order={6}>Campers</Title>
+              <Text>Campers</Text>
               <div className="flex flex-row flex-wrap gap-xs">
                 {Object.keys(parsedData.campers).map((camperIdStr) => {
                   const camperId = parseInt(camperIdStr);
@@ -174,7 +175,7 @@ export function UploadUsersCsvModal() {
                   );
                 })}
               </div>
-              <Title order={6}>Parents</Title>
+              <Text>Parents</Text>
               <div className="flex flex-row flex-wrap gap-xs">
                 {Object.keys(parsedData.parents).map((parentIdStr) => {
                   const parentId = parseInt(parentIdStr);
@@ -187,7 +188,7 @@ export function UploadUsersCsvModal() {
             </>
           ) : (
             <div className="flex flex-col gap-xs">
-              <Title order={6}>Employees</Title>
+              <Text>Employees</Text>
               {parsedData.map((employee) => {
                 return (
                   <div className="flex flex-row justify-between items-center bg-neutral-3 rounded-sm p-xs">

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -24,10 +24,10 @@ const usersCsvTypeToLabel: Record<UsersCsvType, string> = {
 export function UploadUsersCsvModal() {
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [csvType, setCsvType] = useState<UsersCsvType>("FAMILY");
-  const [parsedData, setParsedData] = useState<ParsedUsersCsvData | null>(null);
 
   const parseFamilyCsvMutation = useParseFamilyCsv();
   const parseEmployeeCsvMutation = useParseEmployeeCsv();
+  const parsedData: ParsedUsersCsvData | undefined = csvType === "FAMILY" ? parseFamilyCsvMutation.data : parseEmployeeCsvMutation.data;
 
   const processFamilyCsvMutation = useProcessFamilyCSV();
   const processEmployeeCsvMutation = useProcessEmployeeCSV();
@@ -36,11 +36,13 @@ export function UploadUsersCsvModal() {
     (usersCsvType === "FAMILY"
       ? parseFamilyCsvMutation
       : parseEmployeeCsvMutation
-    ).mutate({ csvFile }, { onSuccess: (data) => setParsedData(data) });
+    ).mutate({ csvFile });
     (usersCsvType === "FAMILY"
       ? parseEmployeeCsvMutation
       : parseFamilyCsvMutation
     ).reset();
+    processFamilyCsvMutation.reset();
+    processEmployeeCsvMutation.reset();
   };
 
   const handleFileSelect: DropzoneProps["onDrop"] = (files) => {
@@ -129,6 +131,16 @@ export function UploadUsersCsvModal() {
       >
         Create Users
       </Button>
+      {processFamilyCsvMutation.error && (
+        <Text className="text-error text-sm text-center">
+          {processFamilyCsvMutation.error.message}
+        </Text>
+      )}
+      {processEmployeeCsvMutation.error && (
+        <Text className="text-error text-sm text-center">
+          {processEmployeeCsvMutation.error.message}
+        </Text>
+      )}
     </div>
   );
 }

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -157,7 +157,7 @@ export function UploadUsersCsvModal() {
           <>
             <Title order={6}>Employees</Title>
             {parsedData.map((employee, i) => {
-              return <><Badge key={employee.id}>{getFullName(employee.name)}</Badge><Select data={["STAFF", "ADMIN", "PHOTOGRAPHER"]} value={roleSelects![i]} onChange={(role) => setRoleSelects(prev => prev ? ({ ...prev, [employee.id]: role }) : null)}/></>;
+              return <><Badge key={employee.id}>{getFullName(employee.name)}</Badge><Select data={["STAFF", "ADMIN", "PHOTOGRAPHER"]} value={roleSelects![employee.id]} onChange={(role) => setRoleSelects(prev => prev ? ({ ...prev, [employee.id]: role }) : null)}/></>;
             })}
           </>
         ))}

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -22,11 +22,17 @@ export function UploadUsersCsvModal() {
     if (!csvFile || !csvType) {
       return;
     } else if (csvType === "FAMILY") {
-      processFamilyCSVMutation.mutate({ csvFile }, { onSuccess: () => modals.closeAll() });
+      processFamilyCSVMutation.mutate(
+        { csvFile },
+        { onSuccess: () => modals.closeAll() },
+      );
       return;
     }
-    processEmployeeCSVMutation.mutate({ csvFile }, { onSuccess: () => modals.closeAll() });
-  }
+    processEmployeeCSVMutation.mutate(
+      { csvFile },
+      { onSuccess: () => modals.closeAll() },
+    );
+  };
 
   return (
     <div className="flex flex-col gap-md">
@@ -36,25 +42,39 @@ export function UploadUsersCsvModal() {
         accept={["text/csv"]}
       >
         <MdOutlineFileUpload size={60} />
-        <Text>{csvFile ? `Selected File: "${csvFile.name}"` : "Upload a users CSV file exported from Campminder here"}</Text>
+        <Text>
+          {csvFile
+            ? `Selected File: "${csvFile.name}"`
+            : "Upload a users CSV file exported from Campminder here"}
+        </Text>
       </Dropzone>
       <Radio.Group
         value={csvType}
         label={"Select the type of CSV file you are uploading"}
       >
         <div className="flex flex-col gap-xs">
-        {usersCsvTypes.map((type) => (
-          <Radio
-            key={type}
-            value={type}
-            label={toNormalCase(type)}
-            onChange={() => setCsvType(type)}
-            required
-          />
-        ))}
+          {usersCsvTypes.map((type) => (
+            <Radio
+              key={type}
+              value={type}
+              label={toNormalCase(type)}
+              onChange={() => setCsvType(type)}
+              required
+            />
+          ))}
         </div>
       </Radio.Group>
-      <Button classNames={{ root: "self-center" }} onClick={handleSubmit} disabled={!csvFile || !csvType} loading={processFamilyCSVMutation.isPending || processEmployeeCSVMutation.isPending}>Create Users</Button>
+      <Button
+        classNames={{ root: "self-center" }}
+        onClick={handleSubmit}
+        disabled={!csvFile || !csvType}
+        loading={
+          processFamilyCSVMutation.isPending ||
+          processEmployeeCSVMutation.isPending
+        }
+      >
+        Create Users
+      </Button>
     </div>
   );
 }

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -15,6 +15,7 @@ import { Dropzone, DropzoneProps } from "@mantine/dropzone";
 import { modals } from "@mantine/modals";
 import { useState } from "react";
 import { MdOutlineFileUpload } from "react-icons/md";
+import { parse } from "path";
 
 const usersCsvTypeToLabel: Record<UsersCsvType, string> = {
   FAMILY: "Families (Campers + Parents)",
@@ -25,6 +26,7 @@ export function UploadUsersCsvModal() {
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [csvType, setCsvType] = useState<UsersCsvType>("FAMILY");
   const [parsedData, setParsedData] = useState<ParsedUsersCsvData | null>(null);
+  const [showParseError, setShowError] = useState<boolean>(false);
 
   const parseFamilyCsvMutation = useParseFamilyCsv();
   const parseEmployeeCsvMutation = useParseEmployeeCsv();
@@ -48,11 +50,17 @@ export function UploadUsersCsvModal() {
     if (!parsedData) {
       return;
     } else if (csvType === "FAMILY" && isParsedFamilyCsvData(parsedData)) {
-      processFamilyCsvMutation.mutate({ parsedFamilyCsvData: parsedData }, { onSuccess: () => modals.closeAll() });
+      processFamilyCsvMutation.mutate(
+        { parsedFamilyCsvData: parsedData },
+        { onSuccess: () => modals.closeAll() },
+      );
     } else if (csvType === "EMPLOYEE" && isParsedEmployeeCsvData(parsedData)) {
-      processEmployeeCsvMutation.mutate({ parsedEmployeeCsvData: parsedData }, { onSuccess: () => modals.closeAll() });
+      processEmployeeCsvMutation.mutate(
+        { parsedEmployeeCsvData: parsedData },
+        { onSuccess: () => modals.closeAll() },
+      );
     }
-  }
+  };
 
   return (
     <div className="flex flex-col gap-md">
@@ -70,6 +78,7 @@ export function UploadUsersCsvModal() {
               : "Upload a users CSV file exported from Campminder here (Max: 5MB)"}
           </Text>
         </Dropzone>
+        {}
       </div>
       <Radio.Group value={csvType} label={"Type of Users"}>
         <div className="flex flex-col gap-xs">
@@ -93,7 +102,10 @@ export function UploadUsersCsvModal() {
         classNames={{ root: "self-center" }}
         onClick={handleSubmit}
         disabled={!csvFile || !csvType}
-        loading={processFamilyCsvMutation.isPending || processEmployeeCsvMutation.isPending}
+        loading={
+          processFamilyCsvMutation.isPending ||
+          processEmployeeCsvMutation.isPending
+        }
       >
         Create Users
       </Button>

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -1,15 +1,13 @@
-import useProcessEmployeeCSV from "@/features/userManagement/useProcessEmployeeCSV";
-import useProcessFamilyCSV from "@/features/userManagement/useProcessFamilyCSV";
+import useProcessUsersCsv, {
+  UsersCsvType,
+  usersCsvTypes,
+} from "@/features/userManagement/useProcessUsersCsv";
 import { MBToBytes } from "@/utils/fileUtils";
 import { Button, Radio, Text } from "@mantine/core";
 import { Dropzone } from "@mantine/dropzone";
 import { modals } from "@mantine/modals";
 import { useState } from "react";
 import { MdOutlineFileUpload } from "react-icons/md";
-
-type UsersCsvType = "FAMILY" | "EMPLOYEE";
-
-const usersCsvTypes: UsersCsvType[] = ["FAMILY", "EMPLOYEE"];
 
 const usersCsvTypeToLabel: Record<UsersCsvType, string> = {
   FAMILY: "Families (Campers + Parents)",
@@ -18,33 +16,19 @@ const usersCsvTypeToLabel: Record<UsersCsvType, string> = {
 
 export function UploadUsersCsvModal() {
   const [csvFile, setCsvFile] = useState<File | null>(null);
-  const [csvType, setCsvType] = useState<UsersCsvType | null>(null);
+  const [csvType, setCsvType] = useState<UsersCsvType>("FAMILY");
 
-  const processFamilyCSVMutation = useProcessFamilyCSV();
-  const processEmployeeCSVMutation = useProcessEmployeeCSV();
+  const processUsersCsvMutation = useProcessUsersCsv(csvType);
 
   const handleSubmit = async () => {
-    if (!csvFile || !csvType) {
-      return;
-    } else if (csvType === "FAMILY") {
-      processFamilyCSVMutation.mutate(
-        { csvFile },
-        { onSuccess: () => modals.closeAll() },
-      );
+    if (!csvFile) {
       return;
     }
-    processEmployeeCSVMutation.mutate(
+    processUsersCsvMutation.mutate(
       { csvFile },
       { onSuccess: () => modals.closeAll() },
     );
   };
-
-  let error = null;
-  if (csvType === "FAMILY") {
-    error = processFamilyCSVMutation.error;
-  } else if (csvType === "EMPLOYEE") {
-    error = processEmployeeCSVMutation.error;
-  }
 
   return (
     <div className="flex flex-col gap-md">
@@ -62,9 +46,9 @@ export function UploadUsersCsvModal() {
               : "Upload a users CSV file exported from Campminder here (Max: 5MB)"}
           </Text>
         </Dropzone>
-        {error && (
+        {processUsersCsvMutation.error && (
           <Text className="text-error text-sm text-center">
-            {error.message}
+            {processUsersCsvMutation.error.message}
           </Text>
         )}
       </div>
@@ -85,10 +69,7 @@ export function UploadUsersCsvModal() {
         classNames={{ root: "self-center" }}
         onClick={handleSubmit}
         disabled={!csvFile || !csvType}
-        loading={
-          processFamilyCSVMutation.isPending ||
-          processEmployeeCSVMutation.isPending
-        }
+        loading={processUsersCsvMutation.isPending}
       >
         Create Users
       </Button>

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -1,3 +1,5 @@
+import useProcessEmployeeCSV from "@/features/userManagement/useProcessEmployeeCSV";
+import useProcessFamilyCSV from "@/features/userManagement/useProcessFamilyCSV";
 import { toNormalCase } from "@/utils/stringUtils";
 import { Button, Radio, Text } from "@mantine/core";
 import { Dropzone } from "@mantine/dropzone";
@@ -12,6 +14,19 @@ const usersCsvTypes: UsersCsvType[] = ["FAMILY", "EMPLOYEE"];
 export function UploadUsersCsvModal() {
   const [csvFile, setCsvFile] = useState<File | null>(null);
   const [csvType, setCsvType] = useState<UsersCsvType | null>(null);
+
+  const processFamilyCSVMutation = useProcessFamilyCSV();
+  const processEmployeeCSVMutation = useProcessEmployeeCSV();
+
+  const handleSubmit = async () => {
+    if (!csvFile || !csvType) {
+      return;
+    } else if (csvType === "FAMILY") {
+      processFamilyCSVMutation.mutate({ csvFile });
+      return;
+    }
+    processEmployeeCSVMutation.mutate({ csvFile });
+  }
 
   return (
     <div className="flex flex-col gap-md">
@@ -39,7 +54,7 @@ export function UploadUsersCsvModal() {
         ))}
         </div>
       </Radio.Group>
-      <Button classNames={{ root: "self-center" }} disabled={!csvFile || !csvType}>Create Users</Button>
+      <Button classNames={{ root: "self-center" }} onClick={handleSubmit} disabled={!csvFile || !csvType} loading={processFamilyCSVMutation.isPending || processEmployeeCSVMutation.isPending}>Create Users</Button>
     </div>
   );
 }

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -27,6 +27,7 @@ export function UploadUsersCsvModal() {
         value={csvType}
         label={"Select the type of CSV file you are uploading"}
       >
+        <div className="flex flex-col gap-xs">
         {usersCsvTypes.map((type) => (
           <Radio
             key={type}
@@ -35,6 +36,7 @@ export function UploadUsersCsvModal() {
             onChange={() => setCsvType(type)}
           />
         ))}
+        </div>
       </Radio.Group>
       <Button classNames={{ root: "self-center" }}>Create Users</Button>
     </div>

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -15,6 +15,7 @@ import {
   Button,
   Loader,
   Radio,
+  ScrollArea,
   Select,
   Text,
   Title,
@@ -159,8 +160,8 @@ export function UploadUsersCsvModal() {
           {parseEmployeeCsvMutation.error.message}
         </Text>
       )}
-      {parsedData &&
-        (isParsedFamilyCsvData(parsedData) ? (
+      {parsedData && <ScrollArea.Autosize className="max-h-[40vh] w-full">
+        {isParsedFamilyCsvData(parsedData) ? (
           <>
             <Title order={6}>Campers</Title>
             {Object.keys(parsedData.campers).map((camperIdStr) => {
@@ -178,7 +179,7 @@ export function UploadUsersCsvModal() {
         ) : (
           <>
             <Title order={6}>Employees</Title>
-            {parsedData.map((employee, i) => {
+            {parsedData.map((employee) => {
               return (
                 <>
                   <Badge key={employee.id}>{getFullName(employee.name)}</Badge>
@@ -196,7 +197,9 @@ export function UploadUsersCsvModal() {
               );
             })}
           </>
-        ))}
+        )}
+      </ScrollArea.Autosize>
+        }
       <Button
         classNames={{ root: "self-center" }}
         onClick={handleSubmit}

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -1,7 +1,5 @@
-import useProcessUsersCsv, {
-  UsersCsvType,
-  usersCsvTypes,
-} from "@/features/userManagement/useProcessUsersCsv";
+import { UsersCsvType, usersCsvTypes } from "@/features/userManagement/types";
+import useProcessUsersCsv from "@/features/userManagement/useProcessUsersCsv";
 import { MBToBytes } from "@/utils/fileUtils";
 import { Button, Radio, Text } from "@mantine/core";
 import { Dropzone } from "@mantine/dropzone";

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -22,10 +22,10 @@ export function UploadUsersCsvModal() {
     if (!csvFile || !csvType) {
       return;
     } else if (csvType === "FAMILY") {
-      processFamilyCSVMutation.mutate({ csvFile });
+      processFamilyCSVMutation.mutate({ csvFile }, { onSuccess: () => modals.closeAll() });
       return;
     }
-    processEmployeeCSVMutation.mutate({ csvFile });
+    processEmployeeCSVMutation.mutate({ csvFile }, { onSuccess: () => modals.closeAll() });
   }
 
   return (

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -38,24 +38,35 @@ export function UploadUsersCsvModal() {
     );
   };
 
+  let error = null;
+  if (csvType === "FAMILY") {
+    error = processFamilyCSVMutation.error;
+  } else if (csvType === "EMPLOYEE") {
+    error = processEmployeeCSVMutation.error;
+  }
+
   return (
     <div className="flex flex-col gap-md">
-      <Dropzone
-        onDrop={(files) => setCsvFile(files[0])}
-        maxFiles={1}
-        accept={["text/csv"]}
-      >
-        <MdOutlineFileUpload size={60} />
-        <Text>
-          {csvFile
-            ? `Selected File: "${csvFile.name}"`
-            : "Upload a users CSV file exported from Campminder here"}
-        </Text>
-      </Dropzone>
-      <Radio.Group
-        value={csvType}
-        label={"Type of Users"}
-      >
+      <div>
+        <Dropzone
+          onDrop={(files) => setCsvFile(files[0])}
+          maxFiles={1}
+          accept={["text/csv"]}
+        >
+          <MdOutlineFileUpload size={60} />
+          <Text>
+            {csvFile
+              ? `Selected File: "${csvFile.name}"`
+              : "Upload a users CSV file exported from Campminder here"}
+          </Text>
+        </Dropzone>
+        {error && (
+          <Text className="text-error text-sm text-center">
+            {error.message}
+          </Text>
+        )}
+      </div>
+      <Radio.Group value={csvType} label={"Type of Users"}>
         <div className="flex flex-col gap-xs">
           {usersCsvTypes.map((type) => (
             <Radio

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -10,7 +10,15 @@ import useParseEmployeeCsv from "@/features/userManagement/useParseEmployeeCsv";
 import useProcessEmployeeCSV from "@/features/userManagement/useProcessEmployeeCSV";
 import useProcessFamilyCSV from "@/features/userManagement/useProcessFamilyCSV";
 import { MBToBytes } from "@/utils/fileUtils";
-import { Badge, Button, Loader, Radio, Select, Text, Title } from "@mantine/core";
+import {
+  Badge,
+  Button,
+  Loader,
+  Radio,
+  Select,
+  Text,
+  Title,
+} from "@mantine/core";
 import { Dropzone, DropzoneProps } from "@mantine/dropzone";
 import { modals } from "@mantine/modals";
 import { useState } from "react";
@@ -41,11 +49,14 @@ export function UploadUsersCsvModal() {
   const processEmployeeCsvMutation = useProcessEmployeeCSV();
 
   const parseCsvFile = (usersCsvType: UsersCsvType, csvFile: File) => {
+    processFamilyCsvMutation.reset();
+    processEmployeeCsvMutation.reset();
     if (usersCsvType === "FAMILY") {
-      parseFamilyCsvMutation.mutate({ csvFile });
       parseEmployeeCsvMutation.reset();
+      parseFamilyCsvMutation.mutate({ csvFile });
       setRoleSelects(null);
     } else {
+      parseFamilyCsvMutation.reset();
       parseEmployeeCsvMutation.mutate(
         { csvFile },
         {
@@ -56,10 +67,14 @@ export function UploadUsersCsvModal() {
           },
         },
       );
-      parseFamilyCsvMutation.reset();
     }
-    processFamilyCsvMutation.reset();
-    processEmployeeCsvMutation.reset();
+  };
+
+  const handleUsersCsvTypeChange = (type: UsersCsvType) => {
+    setCsvType(type);
+    if (csvFile) {
+      parseCsvFile(type, csvFile);
+    }
   };
 
   const handleFileSelect: DropzoneProps["onDrop"] = (files) => {
@@ -71,17 +86,25 @@ export function UploadUsersCsvModal() {
   const handleSubmit = () => {
     if (!parsedData) {
       return;
-    } else if (csvType === "FAMILY" && isParsedFamilyCsvData(parsedData) && !roleSelects) {
+    } else if (
+      csvType === "FAMILY" &&
+      isParsedFamilyCsvData(parsedData) &&
+      !roleSelects
+    ) {
       processFamilyCsvMutation.mutate(
         { parsedFamilyCsvData: parsedData },
         { onSuccess: () => modals.closeAll() },
       );
       processEmployeeCsvMutation.reset();
-    } else if (csvType === "EMPLOYEE" && isParsedEmployeeCsvData(parsedData) && roleSelects) {
-      const employeeData = parsedData.map(employee => ({
+    } else if (
+      csvType === "EMPLOYEE" &&
+      isParsedEmployeeCsvData(parsedData) &&
+      roleSelects
+    ) {
+      const employeeData = parsedData.map((employee) => ({
         ...employee,
-        role: roleSelects[employee.id]
-      }))
+        role: roleSelects[employee.id],
+      }));
       processEmployeeCsvMutation.mutate(
         { parsedEmployeeCsvData: employeeData },
         { onSuccess: () => modals.closeAll() },
@@ -103,12 +126,7 @@ export function UploadUsersCsvModal() {
               key={type}
               value={type}
               label={usersCsvTypeToLabel[type]}
-              onChange={() => {
-                setCsvType(type);
-                if (csvFile) {
-                  parseCsvFile(type, csvFile);
-                }
-              }}
+              onChange={() => handleUsersCsvTypeChange(type)}
               required
             />
           ))}

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -123,7 +123,7 @@ export function UploadUsersCsvModal() {
       <Button
         classNames={{ root: "self-center" }}
         onClick={handleSubmit}
-        disabled={!csvFile || !csvType}
+        disabled={parsedData === undefined}
         loading={
           processFamilyCsvMutation.isPending ||
           processEmployeeCsvMutation.isPending

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -167,9 +167,9 @@ export function UploadUsersCsvModal() {
             before uploading.
           </Title>
           {isParsedFamilyCsvData(parsedData) ? (
-            <>
-              <Text>Campers</Text>
-              <div className="flex flex-row flex-wrap gap-xs">
+            <div className="flex flex-col gap-md">
+              <div className="flex flex-col gap-xs">
+                <Text>Campers</Text>
                 {Object.keys(parsedData.campers).map((camperIdStr) => {
                   const camperId = parseInt(camperIdStr);
                   const camper = parsedData.campers[camperId];
@@ -180,8 +180,8 @@ export function UploadUsersCsvModal() {
                   );
                 })}
               </div>
-              <Text>Parents</Text>
-              <div className="flex flex-row flex-wrap gap-xs">
+              <div className="flex flex-col gap-xs">
+                <Text>Parents</Text>
                 {Object.keys(parsedData.parents).map((parentIdStr) => {
                   const parentId = parseInt(parentIdStr);
                   const parent = parsedData.parents[parentId];
@@ -194,7 +194,7 @@ export function UploadUsersCsvModal() {
                   );
                 })}
               </div>
-            </>
+            </div>
           ) : (
             <div className="flex flex-col gap-xs">
               <Text>Employees</Text>

--- a/src/components/UploadUsersCsvModal.tsx
+++ b/src/components/UploadUsersCsvModal.tsx
@@ -57,11 +57,13 @@ export function UploadUsersCsvModal() {
         { parsedFamilyCsvData: parsedData },
         { onSuccess: () => modals.closeAll() },
       );
+      processEmployeeCsvMutation.reset();
     } else if (csvType === "EMPLOYEE" && isParsedEmployeeCsvData(parsedData)) {
       processEmployeeCsvMutation.mutate(
         { parsedEmployeeCsvData: parsedData },
         { onSuccess: () => modals.closeAll() },
       );
+      processFamilyCsvMutation.reset();
     }
   };
 

--- a/src/features/userManagement/types.ts
+++ b/src/features/userManagement/types.ts
@@ -1,2 +1,11 @@
+import { Camper, Parent, UnregisteredEmployee } from "@/types/users/userTypes";
+
 export type UsersCsvType = "FAMILY" | "EMPLOYEE";
 export const usersCsvTypes: UsersCsvType[] = ["FAMILY", "EMPLOYEE"];
+
+export interface ParsedFamilyCsvData {
+  campers: { [camperId: number]: Pick<Camper, "id" | "name" | "parentIds">; };
+  parents: { [parentId: number]: Pick<Parent, "id" | "name" | "email" | "camperIds">; };
+}
+
+export type ParsedEmployeeCsvData = Omit<UnregisteredEmployee, "role">[]

--- a/src/features/userManagement/types.ts
+++ b/src/features/userManagement/types.ts
@@ -1,0 +1,2 @@
+export type UsersCsvType = "FAMILY" | "EMPLOYEE";
+export const usersCsvTypes: UsersCsvType[] = ["FAMILY", "EMPLOYEE"];

--- a/src/features/userManagement/types.ts
+++ b/src/features/userManagement/types.ts
@@ -7,5 +7,13 @@ export interface ParsedFamilyCsvData {
   campers: { [camperId: number]: Pick<Camper, "id" | "name" | "parentIds">; };
   parents: { [parentId: number]: Pick<Parent, "id" | "name" | "email" | "camperIds">; };
 }
+export type ParsedEmployeeCsvData = Omit<UnregisteredEmployee, "role">[];
+export type ParsedUsersCsvData = ParsedFamilyCsvData | ParsedEmployeeCsvData;
 
-export type ParsedEmployeeCsvData = Omit<UnregisteredEmployee, "role">[]
+export function isParsedFamilyCsvData(data: ParsedUsersCsvData): data is ParsedFamilyCsvData {
+  return "campers" in data && "parents" in data;
+}
+
+export function isParsedEmployeeCsvData(data: ParsedUsersCsvData): data is ParsedEmployeeCsvData {
+  return Array.isArray(data);
+}

--- a/src/features/userManagement/useParseEmployeeCsv.ts
+++ b/src/features/userManagement/useParseEmployeeCsv.ts
@@ -1,17 +1,31 @@
 import { useMutation } from "@tanstack/react-query";
-import { parse } from "csv-parse/sync";
+import { Info, parse } from "csv-parse/sync";
 import { ParsedEmployeeCsvData } from "./types";
+import { z } from "zod";
 
 interface ParseEmployeeCsvRequest {
   csvFile: File;
 }
 
-interface EmployeeCSVRecord {
+interface RawEmployeeCSVRecord {
   "First Name": string;
   "Last Name": string;
   PersonID: string;
   "Login/Email": string;
 }
+
+interface RawEmployeeCsvRecordWithInfo {
+  record: RawEmployeeCSVRecord;
+  info: Info;
+}
+
+const EmployeeCsvRecordSchema = z.object({
+  "First Name": z.string().min(1),
+  "Last Name": z.string().min(1),
+  PersonID: z.preprocess(value => value === "" ? NaN : value, z.coerce.number()),
+  "Login/Email": z.string().email(),
+})
+type ParsedEmployeeCsvRecord = z.infer<typeof EmployeeCsvRecordSchema>;
 
 const REQUIRED_COLUMNS = [
   "First Name",
@@ -23,7 +37,7 @@ const REQUIRED_COLUMNS = [
 export async function parseEmployeeCsv(req: ParseEmployeeCsvRequest): Promise<ParsedEmployeeCsvData> {
   const { csvFile } = req;
   const rawText = await csvFile.text();
-  const records = parse(rawText, {
+  const data = parse(rawText, {
     columns: (cols: string[]) => {
       const missingColumns = REQUIRED_COLUMNS.filter(col => !cols.includes(col));
       if (missingColumns.length > 0) {
@@ -31,16 +45,24 @@ export async function parseEmployeeCsv(req: ParseEmployeeCsvRequest): Promise<Pa
       }
       return cols;
     },
+    info: true,
     skip_empty_lines: true
-  }) as EmployeeCSVRecord[];
-  return records.filter(record => !Number.isNaN(parseInt(record.PersonID))).map(record => ({
-    id: parseInt(record.PersonID),
-    name: {
-      firstName: record["First Name"],
-      lastName: record["Last Name"]
-    },
-    email: record["Login/Email"]
-  }));
+  }) as RawEmployeeCsvRecordWithInfo[];
+  return data.map(({ record, info }) => {
+    const validationResult = EmployeeCsvRecordSchema.safeParse(record);
+    if (!validationResult.success) {
+      throw Error(`Invalid record on line ${info.lines}. Please fix before uploading.`);
+    }
+    const parsedRecord: ParsedEmployeeCsvRecord = validationResult.data;
+    return {
+      id: parsedRecord.PersonID,
+      name: {
+        firstName: record["First Name"],
+        lastName: record["Last Name"]
+      },
+      email: record["Login/Email"]
+    }
+  });
 }
 
 export default function useParseEmployeeCsv() {

--- a/src/features/userManagement/useParseEmployeeCsv.ts
+++ b/src/features/userManagement/useParseEmployeeCsv.ts
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
-import { UnregisteredEmployee } from "@/types/users/userTypes";
 import { parse } from "csv-parse/sync";
+import { ParsedEmployeeCsvData } from "./types";
 
 interface ParseEmployeeCsvRequest {
   csvFile: File;
@@ -20,7 +20,7 @@ const REQUIRED_COLUMNS = [
   "Login/Email"
 ]
 
-export async function parseEmployeeCsv(req: ParseEmployeeCsvRequest): Promise<Omit<UnregisteredEmployee, "role">[]> {
+export async function parseEmployeeCsv(req: ParseEmployeeCsvRequest): Promise<ParsedEmployeeCsvData> {
   const { csvFile } = req;
   const rawText = await csvFile.text();
   const records = parse(rawText, {

--- a/src/features/userManagement/useParseEmployeeCsv.ts
+++ b/src/features/userManagement/useParseEmployeeCsv.ts
@@ -1,5 +1,10 @@
+import { useMutation } from "@tanstack/react-query";
 import { UnregisteredEmployee } from "@/types/users/userTypes";
 import { parse } from "csv-parse/sync";
+
+interface ParseEmployeeCsvRequest {
+  csvFile: File;
+}
 
 interface EmployeeCSVRecord {
   "First Name": string;
@@ -15,8 +20,9 @@ const REQUIRED_COLUMNS = [
   "Login/Email"
 ]
 
-export async function parseEmployeeCSV(file: File): Promise<Omit<UnregisteredEmployee, "role">[]> {
-  const rawText = await file.text();
+export async function parseEmployeeCsv(req: ParseEmployeeCsvRequest): Promise<Omit<UnregisteredEmployee, "role">[]> {
+  const { csvFile } = req;
+  const rawText = await csvFile.text();
   const records = parse(rawText, {
     columns: (cols: string[]) => {
       const missingColumns = REQUIRED_COLUMNS.filter(col => !cols.includes(col));
@@ -35,4 +41,10 @@ export async function parseEmployeeCSV(file: File): Promise<Omit<UnregisteredEmp
     },
     email: record["Login/Email"]
   }));
+}
+
+export default function useParseEmployeeCsv() {
+  return useMutation({
+    mutationFn: (req: ParseEmployeeCsvRequest) => parseEmployeeCsv(req)
+  })
 }

--- a/src/features/userManagement/useParseFamilyCsv.ts
+++ b/src/features/userManagement/useParseFamilyCsv.ts
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
-import { Camper, Parent } from "@/types/users/userTypes";
 import { parse } from "csv-parse/sync";
+import { ParsedFamilyCsvData } from "./types";
 
 interface ParseFamilyCsvRequest {
   csvFile: File;
@@ -23,14 +23,9 @@ type FamilyCSVRecord = BaseFamilyCSVRecord | BaseFamilyCSVRecord & {
   "F1P2 Login/Email": string;
 };
 
-export interface ParseFamilyCSVResponse {
-  campers: { [camperId: number]: Pick<Camper, "id" | "name" | "parentIds">; };
-  parents: { [parentId: number]: Pick<Parent, "id" | "name" | "email" | "camperIds">; };
-}
-
-function parseFamilyRecords(records: FamilyCSVRecord[]): ParseFamilyCSVResponse {
-  const campers: ParseFamilyCSVResponse["campers"] = {};
-  const parents: ParseFamilyCSVResponse["parents"] = {};
+function parseFamilyRecords(records: FamilyCSVRecord[]): ParsedFamilyCsvData {
+  const campers: ParsedFamilyCsvData["campers"] = {};
+  const parents: ParsedFamilyCsvData["parents"] = {};
 
   records.forEach((record) => {
     const camperId: number = parseInt(record.PersonID);
@@ -93,7 +88,7 @@ const REQUIRED_COLUMNS = [
   "F1P1 Login/Email"
 ]
 
-export async function parseFamilyCsv(req: ParseFamilyCsvRequest): Promise<ParseFamilyCSVResponse> {
+export async function parseFamilyCsv(req: ParseFamilyCsvRequest): Promise<ParsedFamilyCsvData> {
   const { csvFile } = req;
   const rawText = await csvFile.text();
   const records = parse(rawText, {

--- a/src/features/userManagement/useParseFamilyCsv.ts
+++ b/src/features/userManagement/useParseFamilyCsv.ts
@@ -1,5 +1,10 @@
+import { useMutation } from "@tanstack/react-query";
 import { Camper, Parent } from "@/types/users/userTypes";
 import { parse } from "csv-parse/sync";
+
+interface ParseFamilyCsvRequest {
+  csvFile: File;
+}
 
 interface BaseFamilyCSVRecord {
   "First Name": string;
@@ -88,8 +93,9 @@ const REQUIRED_COLUMNS = [
   "F1P1 Login/Email"
 ]
 
-export async function parseFamilyCSV(file: File): Promise<ParseFamilyCSVResponse> {
-  const rawText = await file.text();
+export async function parseFamilyCsv(req: ParseFamilyCsvRequest): Promise<ParseFamilyCSVResponse> {
+  const { csvFile } = req;
+  const rawText = await csvFile.text();
   const records = parse(rawText, {
     columns: (cols: string[]) => {
       const missingColumns = REQUIRED_COLUMNS.filter(col => !cols.includes(col));
@@ -101,4 +107,10 @@ export async function parseFamilyCSV(file: File): Promise<ParseFamilyCSVResponse
     skip_empty_lines: true
   }) as FamilyCSVRecord[];
   return parseFamilyRecords(records);
+}
+
+export default function useParseFamilyCsv() {
+  return useMutation({
+    mutationFn: (req: ParseFamilyCsvRequest) => parseFamilyCsv(req)
+  })
 }

--- a/src/features/userManagement/useParseFamilyCsv.ts
+++ b/src/features/userManagement/useParseFamilyCsv.ts
@@ -49,10 +49,10 @@ const BaseFamilyCsvRecordSchema = z.object({
 })
 
 const FamilyCsvRecordOneParentSchema = z.object({
-  "F1P2 First Name": z.string().max(0),
-  "F1P2 Last Name": z.string().max(0),
-  "F1P2 Person ID": z.string().max(0),
-  "F1P2 Login/Email": z.string().max(0),
+  "F1P2 First Name": z.string().max(0).transform(() => undefined),
+  "F1P2 Last Name": z.string().max(0).transform(() => undefined),
+  "F1P2 Person ID": z.string().max(0).transform(() => undefined),
+  "F1P2 Login/Email": z.string().max(0).transform(() => undefined),
 });
 
 const FamilyCsvRecordTwoParentsSchema = z.object({

--- a/src/features/userManagement/useParseFamilyCsv.ts
+++ b/src/features/userManagement/useParseFamilyCsv.ts
@@ -62,31 +62,30 @@ const FamilyCsvRecordTwoParentsSchema = z.object({
   "F1P2 Login/Email": z.string().email(),
 })
 
-const FamilyCsvRecordSchema = BaseFamilyCsvRecordSchema.and(FamilyCsvRecordOneParentSchema.or(FamilyCsvRecordTwoParentsSchema));
+const ParsedFamilyCsvRecordSchema = BaseFamilyCsvRecordSchema.and(FamilyCsvRecordOneParentSchema.or(FamilyCsvRecordTwoParentsSchema));
+type ParsedFamilyCsvRecord = z.infer<typeof ParsedFamilyCsvRecordSchema>;
 
 function parseFamilyRecords(data: FamilyCsvRecordWithInfo[]): ParsedFamilyCsvData {
   const campers: ParsedFamilyCsvData["campers"] = {};
   const parents: ParsedFamilyCsvData["parents"] = {};
 
   data.forEach(({ record, info }) => {
-    const camperId: number = parseInt(record.PersonID);
-    const parent1Id: number = parseInt(record["F1P1 Person ID"]);
-    const parent2Id: number = "F1P2 Person ID" in record ? parseInt(record["F1P2 Person ID"]) : NaN;
-
-    const validationResult = FamilyCsvRecordSchema.safeParse(record);
+    const validationResult = ParsedFamilyCsvRecordSchema.safeParse(record);
     if (!validationResult.success) {
-      console.log(validationResult)
-    const errorPrefix = `Invalid record on line ${info.lines}: `;
-
+      throw Error(`Invalid record on line ${info.lines}. Please fix before uploading.`);
     }
 
+    const parsedRecord: ParsedFamilyCsvRecord = validationResult.data;
+    const camperId = parsedRecord.PersonID;
+    const parent1Id = parsedRecord["F1P1 Person ID"];
+    const parent2Id = parsedRecord["F1P2 Person ID"];
     campers[camperId] = {
-      id: parseInt(record.PersonID),
+      id: camperId,
       name: {
         firstName: record["First Name"],
         lastName: record["Last Name"],
       },
-      parentIds: Number.isNaN(parent2Id)
+      parentIds: parent2Id === undefined
         ? [parent1Id]
         : [parent1Id, parent2Id],
     };
@@ -105,7 +104,7 @@ function parseFamilyRecords(data: FamilyCsvRecordWithInfo[]): ParsedFamilyCsvDat
       }
     }
 
-    if ("F1P2 Person ID" in record && !Number.isNaN(parent2Id)) {
+    if (parent2Id) {
       if (parents[parent2Id]) {
         parents[parent2Id].camperIds.push(camperId);
       } else {

--- a/src/features/userManagement/useParseFamilyCsv.ts
+++ b/src/features/userManagement/useParseFamilyCsv.ts
@@ -41,10 +41,10 @@ type FamilyCsvRecordWithInfo = {
 const BaseFamilyCsvRecordSchema = z.object({
   "First Name": z.string().min(1),
   "Last Name": z.string().min(1),
-  PersonID: z.coerce.number(),
+  PersonID: z.preprocess(value => value === "" ? NaN : value, z.coerce.number()),
   "F1P1 First Name": z.string().min(1),
   "F1P1 Last Name": z.string().min(1),
-  "F1P1 Person ID": z.coerce.number(),
+  "F1P1 Person ID": z.preprocess(value => value === "" ? NaN : value, z.coerce.number()),
   "F1P1 Login/Email": z.string().email(),
 })
 
@@ -58,7 +58,7 @@ const FamilyCsvRecordOneParentSchema = z.object({
 const FamilyCsvRecordTwoParentsSchema = z.object({
   "F1P2 First Name": z.string().min(1),
   "F1P2 Last Name": z.string().min(1),
-  "F1P2 Person ID": z.coerce.number(),
+  "F1P2 Person ID": z.preprocess(value => value === "" ? NaN : value, z.coerce.number()),
   "F1P2 Login/Email": z.string().email(),
 })
 

--- a/src/features/userManagement/useParseFamilyCsv.ts
+++ b/src/features/userManagement/useParseFamilyCsv.ts
@@ -1,6 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { parse, Info } from "csv-parse/sync";
 import { ParsedFamilyCsvData } from "./types";
+import { z } from "zod";
 
 interface ParseFamilyCsvRequest {
   csvFile: File;
@@ -37,6 +38,32 @@ type FamilyCsvRecordWithInfo = {
   info: Info;
 };
 
+const BaseFamilyCsvRecordSchema = z.object({
+  "First Name": z.string().min(1),
+  "Last Name": z.string().min(1),
+  PersonID: z.coerce.number(),
+  "F1P1 First Name": z.string().min(1),
+  "F1P1 Last Name": z.string().min(1),
+  "F1P1 Person ID": z.coerce.number(),
+  "F1P1 Login/Email": z.string().min(1),
+})
+
+const FamilyCsvRecordOneParentSchema = z.object({
+  "F1P2 First Name": z.string().max(0),
+  "F1P2 Last Name": z.string().max(0),
+  "F1P2 Person ID": z.string().max(0),
+  "F1P2 Login/Email": z.string().max(0),
+});
+
+const FamilyCsvRecordTwoParentsSchema = z.object({
+  "F1P2 First Name": z.string().min(1),
+  "F1P2 Last Name": z.string().min(1),
+  "F1P2 Person ID": z.coerce.number(),
+  "F1P2 Login/Email": z.string().min(1),
+})
+
+const FamilyCsvRecordSchema = BaseFamilyCsvRecordSchema.and(FamilyCsvRecordOneParentSchema.or(FamilyCsvRecordTwoParentsSchema));
+
 function parseFamilyRecords(data: FamilyCsvRecordWithInfo[]): ParsedFamilyCsvData {
   const campers: ParsedFamilyCsvData["campers"] = {};
   const parents: ParsedFamilyCsvData["parents"] = {};
@@ -46,7 +73,12 @@ function parseFamilyRecords(data: FamilyCsvRecordWithInfo[]): ParsedFamilyCsvDat
     const parent1Id: number = parseInt(record["F1P1 Person ID"]);
     const parent2Id: number = "F1P2 Person ID" in record ? parseInt(record["F1P2 Person ID"]) : NaN;
 
+    const validationResult = FamilyCsvRecordSchema.safeParse(record);
+    if (!validationResult.success) {
+      console.log(validationResult)
+    const errorPrefix = `Invalid record on line ${info.lines}: `;
 
+    }
 
     campers[camperId] = {
       id: parseInt(record.PersonID),

--- a/src/features/userManagement/useParseFamilyCsv.ts
+++ b/src/features/userManagement/useParseFamilyCsv.ts
@@ -1,5 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
-import { parse } from "csv-parse/sync";
+import { parse, Info } from "csv-parse/sync";
 import { ParsedFamilyCsvData } from "./types";
 
 interface ParseFamilyCsvRequest {
@@ -16,23 +16,37 @@ interface BaseFamilyCSVRecord {
   "F1P1 Login/Email": string;
 }
 
-type FamilyCSVRecord = BaseFamilyCSVRecord | BaseFamilyCSVRecord & {
+interface FamilyCsvRecordOneParent extends BaseFamilyCSVRecord {
+  "F1P2 First Name": "";
+  "F1P2 Last Name": "";
+  "F1P2 Person ID": "";
+  "F1P2 Login/Email": "";
+}
+
+interface FamilyCsvRecordTwoParents extends BaseFamilyCSVRecord {
   "F1P2 First Name": string;
   "F1P2 Last Name": string;
   "F1P2 Person ID": string;
   "F1P2 Login/Email": string;
+}
+
+type FamilyCSVRecord = FamilyCsvRecordOneParent | FamilyCsvRecordTwoParents;
+
+type FamilyCsvRecordWithInfo = {
+  record: FamilyCSVRecord;
+  info: Info;
 };
 
-function parseFamilyRecords(records: FamilyCSVRecord[]): ParsedFamilyCsvData {
+function parseFamilyRecords(data: FamilyCsvRecordWithInfo[]): ParsedFamilyCsvData {
   const campers: ParsedFamilyCsvData["campers"] = {};
   const parents: ParsedFamilyCsvData["parents"] = {};
 
-  records.forEach((record) => {
+  data.forEach(({ record, info }) => {
     const camperId: number = parseInt(record.PersonID);
     const parent1Id: number = parseInt(record["F1P1 Person ID"]);
     const parent2Id: number = "F1P2 Person ID" in record ? parseInt(record["F1P2 Person ID"]) : NaN;
 
-    if (Number.isNaN(camperId) || Number.isNaN(parent1Id)) return;
+
 
     campers[camperId] = {
       id: parseInt(record.PersonID),
@@ -91,7 +105,7 @@ const REQUIRED_COLUMNS = [
 export async function parseFamilyCsv(req: ParseFamilyCsvRequest): Promise<ParsedFamilyCsvData> {
   const { csvFile } = req;
   const rawText = await csvFile.text();
-  const records = parse(rawText, {
+  const data = parse(rawText, {
     columns: (cols: string[]) => {
       const missingColumns = REQUIRED_COLUMNS.filter(col => !cols.includes(col));
       if (missingColumns.length > 0) {
@@ -99,9 +113,10 @@ export async function parseFamilyCsv(req: ParseFamilyCsvRequest): Promise<Parsed
       }
       return cols;
     },
+    info: true,
     skip_empty_lines: true
-  }) as FamilyCSVRecord[];
-  return parseFamilyRecords(records);
+  }) as FamilyCsvRecordWithInfo[];
+  return parseFamilyRecords(data);
 }
 
 export default function useParseFamilyCsv() {

--- a/src/features/userManagement/useParseFamilyCsv.ts
+++ b/src/features/userManagement/useParseFamilyCsv.ts
@@ -45,7 +45,7 @@ const BaseFamilyCsvRecordSchema = z.object({
   "F1P1 First Name": z.string().min(1),
   "F1P1 Last Name": z.string().min(1),
   "F1P1 Person ID": z.coerce.number(),
-  "F1P1 Login/Email": z.string().min(1),
+  "F1P1 Login/Email": z.string().email(),
 })
 
 const FamilyCsvRecordOneParentSchema = z.object({
@@ -59,7 +59,7 @@ const FamilyCsvRecordTwoParentsSchema = z.object({
   "F1P2 First Name": z.string().min(1),
   "F1P2 Last Name": z.string().min(1),
   "F1P2 Person ID": z.coerce.number(),
-  "F1P2 Login/Email": z.string().min(1),
+  "F1P2 Login/Email": z.string().email(),
 })
 
 const FamilyCsvRecordSchema = BaseFamilyCsvRecordSchema.and(FamilyCsvRecordOneParentSchema.or(FamilyCsvRecordTwoParentsSchema));

--- a/src/features/userManagement/useParseFamilyCsv.ts
+++ b/src/features/userManagement/useParseFamilyCsv.ts
@@ -7,7 +7,7 @@ interface ParseFamilyCsvRequest {
   csvFile: File;
 }
 
-interface BaseFamilyCSVRecord {
+interface BaseRawFamilyCSVRecord {
   "First Name": string;
   "Last Name": string;
   PersonID: string;
@@ -17,24 +17,24 @@ interface BaseFamilyCSVRecord {
   "F1P1 Login/Email": string;
 }
 
-interface FamilyCsvRecordOneParent extends BaseFamilyCSVRecord {
+interface RawFamilyCsvRecordOneParent extends BaseRawFamilyCSVRecord {
   "F1P2 First Name": "";
   "F1P2 Last Name": "";
   "F1P2 Person ID": "";
   "F1P2 Login/Email": "";
 }
 
-interface FamilyCsvRecordTwoParents extends BaseFamilyCSVRecord {
+interface RawFamilyCsvRecordTwoParents extends BaseRawFamilyCSVRecord {
   "F1P2 First Name": string;
   "F1P2 Last Name": string;
   "F1P2 Person ID": string;
   "F1P2 Login/Email": string;
 }
 
-type FamilyCSVRecord = FamilyCsvRecordOneParent | FamilyCsvRecordTwoParents;
+type RawFamilyCSVRecord = RawFamilyCsvRecordOneParent | RawFamilyCsvRecordTwoParents;
 
-type FamilyCsvRecordWithInfo = {
-  record: FamilyCSVRecord;
+type RawFamilyCsvRecordWithInfo = {
+  record: RawFamilyCSVRecord;
   info: Info;
 };
 
@@ -65,7 +65,7 @@ const FamilyCsvRecordTwoParentsSchema = z.object({
 const ParsedFamilyCsvRecordSchema = BaseFamilyCsvRecordSchema.and(FamilyCsvRecordOneParentSchema.or(FamilyCsvRecordTwoParentsSchema));
 type ParsedFamilyCsvRecord = z.infer<typeof ParsedFamilyCsvRecordSchema>;
 
-function parseFamilyRecords(data: FamilyCsvRecordWithInfo[]): ParsedFamilyCsvData {
+function parseFamilyRecords(data: RawFamilyCsvRecordWithInfo[]): ParsedFamilyCsvData {
   const campers: ParsedFamilyCsvData["campers"] = {};
   const parents: ParsedFamilyCsvData["parents"] = {};
 
@@ -104,7 +104,7 @@ function parseFamilyRecords(data: FamilyCsvRecordWithInfo[]): ParsedFamilyCsvDat
       }
     }
 
-    if (parent2Id) {
+    if (parent2Id !== undefined) {
       if (parents[parent2Id]) {
         parents[parent2Id].camperIds.push(camperId);
       } else {
@@ -146,7 +146,7 @@ export async function parseFamilyCsv(req: ParseFamilyCsvRequest): Promise<Parsed
     },
     info: true,
     skip_empty_lines: true
-  }) as FamilyCsvRecordWithInfo[];
+  }) as RawFamilyCsvRecordWithInfo[];
   return parseFamilyRecords(data);
 }
 

--- a/src/features/userManagement/useParseUsersCsv.ts
+++ b/src/features/userManagement/useParseUsersCsv.ts
@@ -1,6 +1,6 @@
 import useParseFamilyCsv from "./useParseFamilyCsv";
 import useParseEmployeeCsv from "./useParseEmployeeCsv";
-import { UsersCsvType } from "./useProcessUsersCsv";
+import { UsersCsvType } from "./types";
 
 export default function useProcessUsersCsv(usersCsvType: UsersCsvType) {
   const parseFamilyCsvMutation = useParseFamilyCsv();

--- a/src/features/userManagement/useParseUsersCsv.ts
+++ b/src/features/userManagement/useParseUsersCsv.ts
@@ -1,9 +1,0 @@
-import useParseFamilyCsv from "./useParseFamilyCsv";
-import useParseEmployeeCsv from "./useParseEmployeeCsv";
-import { UsersCsvType } from "./types";
-
-export default function useProcessUsersCsv(usersCsvType: UsersCsvType) {
-  const parseFamilyCsvMutation = useParseFamilyCsv();
-  const parseEmployeeCsvMutation = useParseEmployeeCsv();
-  return usersCsvType === "FAMILY" ? parseFamilyCsvMutation : parseEmployeeCsvMutation
-}

--- a/src/features/userManagement/useParseUsersCsv.ts
+++ b/src/features/userManagement/useParseUsersCsv.ts
@@ -1,0 +1,9 @@
+import useParseFamilyCsv from "./useParseFamilyCsv";
+import useParseEmployeeCsv from "./useParseEmployeeCsv";
+import { UsersCsvType } from "./useProcessUsersCsv";
+
+export default function useProcessUsersCsv(usersCsvType: UsersCsvType) {
+  const parseFamilyCsvMutation = useParseFamilyCsv();
+  const parseEmployeeCsvMutation = useParseEmployeeCsv();
+  return usersCsvType === "FAMILY" ? parseFamilyCsvMutation : parseEmployeeCsvMutation
+}

--- a/src/features/userManagement/useProcessEmployeeCSV.ts
+++ b/src/features/userManagement/useProcessEmployeeCSV.ts
@@ -1,0 +1,20 @@
+import { httpsCallable } from "firebase/functions";
+import { functions } from "@/config/firebase";
+import { useMutation } from "@tanstack/react-query";
+import { parseEmployeeCSV } from "./parseEmployeeCSV";
+
+interface ProcessEmployeeCSVRequest {
+  csvFile: File;
+}
+
+async function processEmployeeCSV(req: ProcessEmployeeCSVRequest) {
+  const { csvFile } = req;
+  const parsedData = await parseEmployeeCSV(csvFile);
+  await httpsCallable(functions, "handleEmployeeCSVUpload")(parsedData);
+}
+
+export default function useProcessEmployeeCSV() {
+  return useMutation({
+    mutationFn: (req: ProcessEmployeeCSVRequest) => processEmployeeCSV(req)
+  })
+}

--- a/src/features/userManagement/useProcessEmployeeCSV.ts
+++ b/src/features/userManagement/useProcessEmployeeCSV.ts
@@ -1,10 +1,10 @@
 import { httpsCallable } from "firebase/functions";
 import { functions } from "@/config/firebase";
 import { useMutation } from "@tanstack/react-query";
-import { ParsedEmployeeCsvData } from "./types";
+import { UnregisteredEmployee } from "@/types/users/userTypes";
 
 interface ProcessEmployeeCSVRequest {
-  parsedEmployeeCsvData: ParsedEmployeeCsvData;
+  parsedEmployeeCsvData: UnregisteredEmployee[];
 }
 
 async function processEmployeeCSV(req: ProcessEmployeeCSVRequest) {

--- a/src/features/userManagement/useProcessEmployeeCSV.ts
+++ b/src/features/userManagement/useProcessEmployeeCSV.ts
@@ -1,16 +1,15 @@
 import { httpsCallable } from "firebase/functions";
 import { functions } from "@/config/firebase";
 import { useMutation } from "@tanstack/react-query";
-import { parseEmployeeCSV } from "./parseEmployeeCSV";
+import { ParsedEmployeeCsvData } from "./types";
 
 interface ProcessEmployeeCSVRequest {
-  csvFile: File;
+  parsedEmployeeCsvData: ParsedEmployeeCsvData;
 }
 
 async function processEmployeeCSV(req: ProcessEmployeeCSVRequest) {
-  const { csvFile } = req;
-  const parsedData = await parseEmployeeCSV(csvFile);
-  await httpsCallable(functions, "handleEmployeeCSVUpload")(parsedData);
+  const { parsedEmployeeCsvData } = req;
+  await httpsCallable(functions, "handleEmployeeCSVUpload")(parsedEmployeeCsvData);
 }
 
 export default function useProcessEmployeeCSV() {

--- a/src/features/userManagement/useProcessFamilyCSV.ts
+++ b/src/features/userManagement/useProcessFamilyCSV.ts
@@ -1,0 +1,20 @@
+import { httpsCallable } from "firebase/functions";
+import { parseFamilyCSV } from "./parseFamilyCSV";
+import { functions } from "@/config/firebase";
+import { useMutation } from "@tanstack/react-query";
+
+interface ProcessFamilyCSVRequest {
+  csvFile: File;
+}
+
+async function processFamilyCSV(req: ProcessFamilyCSVRequest) {
+  const { csvFile } = req;
+  const parsedData = await parseFamilyCSV(csvFile);
+  await httpsCallable(functions, "handleFamilyCSVUpload")(parsedData);
+}
+
+export default function useProcessFamilyCSV() {
+  return useMutation({
+    mutationFn: (req: ProcessFamilyCSVRequest) => processFamilyCSV(req)
+  })
+}

--- a/src/features/userManagement/useProcessFamilyCSV.ts
+++ b/src/features/userManagement/useProcessFamilyCSV.ts
@@ -1,16 +1,15 @@
 import { httpsCallable } from "firebase/functions";
-import { parseFamilyCSV } from "./parseFamilyCSV";
 import { functions } from "@/config/firebase";
 import { useMutation } from "@tanstack/react-query";
+import { ParsedFamilyCsvData } from "./types";
 
 interface ProcessFamilyCSVRequest {
-  csvFile: File;
+  parsedFamilyCsvData: ParsedFamilyCsvData;
 }
 
 async function processFamilyCSV(req: ProcessFamilyCSVRequest) {
-  const { csvFile } = req;
-  const parsedData = await parseFamilyCSV(csvFile);
-  await httpsCallable(functions, "handleFamilyCSVUpload")(parsedData);
+  const { parsedFamilyCsvData } = req;
+  await httpsCallable(functions, "handleFamilyCSVUpload")(parsedFamilyCsvData);
 }
 
 export default function useProcessFamilyCSV() {

--- a/src/features/userManagement/useProcessUsersCsv.ts
+++ b/src/features/userManagement/useProcessUsersCsv.ts
@@ -1,9 +1,0 @@
-import useProcessFamilyCSV from "./useProcessFamilyCSV";
-import useProcessEmployeeCSV from "./useProcessEmployeeCSV";
-import { UsersCsvType } from "./types";
-
-export default function useProcessUsersCsv(usersCsvType: UsersCsvType) {
-  const processFamilyCSVMutation = useProcessFamilyCSV();
-  const processEmployeeCSVMutation = useProcessEmployeeCSV();
-  return usersCsvType === "FAMILY" ? processFamilyCSVMutation : processEmployeeCSVMutation
-}

--- a/src/features/userManagement/useProcessUsersCsv.ts
+++ b/src/features/userManagement/useProcessUsersCsv.ts
@@ -1,0 +1,11 @@
+import useProcessFamilyCSV from "./useProcessFamilyCSV";
+import useProcessEmployeeCSV from "./useProcessEmployeeCSV";
+
+export type UsersCsvType = "FAMILY" | "EMPLOYEE";
+export const usersCsvTypes: UsersCsvType[] = ["FAMILY", "EMPLOYEE"];
+
+export default function useProcessUsersCsv(usersCsvType: UsersCsvType) {
+  const processFamilyCSVMutation = useProcessFamilyCSV();
+  const processEmployeeCSVMutation = useProcessEmployeeCSV();
+  return usersCsvType === "FAMILY" ? processFamilyCSVMutation : processEmployeeCSVMutation
+}

--- a/src/features/userManagement/useProcessUsersCsv.ts
+++ b/src/features/userManagement/useProcessUsersCsv.ts
@@ -1,8 +1,6 @@
 import useProcessFamilyCSV from "./useProcessFamilyCSV";
 import useProcessEmployeeCSV from "./useProcessEmployeeCSV";
-
-export type UsersCsvType = "FAMILY" | "EMPLOYEE";
-export const usersCsvTypes: UsersCsvType[] = ["FAMILY", "EMPLOYEE"];
+import { UsersCsvType } from "./types";
 
 export default function useProcessUsersCsv(usersCsvType: UsersCsvType) {
   const processFamilyCSVMutation = useProcessFamilyCSV();

--- a/src/styles/components/DropzoneThemeExtension.ts
+++ b/src/styles/components/DropzoneThemeExtension.ts
@@ -2,7 +2,7 @@ import { Dropzone } from "@mantine/dropzone";
 
 const DropzoneThemeExtension = Dropzone.extend({
   classNames: {
-    inner: 'flex flex-col justify-center items-center bg-neutral-2 hover:bg-neutral-3 border-4 border-dashed border-orange-5 rounded-lg my-2 p-2 cursor-pointer',
+    inner: 'flex flex-col justify-center items-center bg-neutral-2 hover:bg-neutral-3 border-4 border-dashed border-orange-5 rounded-lg my-2 p-2 cursor-pointer text-center',
   }
 });
 

--- a/src/styles/components/DropzoneThemeExtension.ts
+++ b/src/styles/components/DropzoneThemeExtension.ts
@@ -2,7 +2,7 @@ import { Dropzone } from "@mantine/dropzone";
 
 const DropzoneThemeExtension = Dropzone.extend({
   classNames: {
-    inner: 'cursor-pointer'
+    inner: 'flex flex-col justify-center items-center border-4 border-dashed border-orange-5 rounded-lg my-2 p-2 cursor-pointer',
   }
 });
 

--- a/src/styles/components/DropzoneThemeExtension.ts
+++ b/src/styles/components/DropzoneThemeExtension.ts
@@ -2,7 +2,7 @@ import { Dropzone } from "@mantine/dropzone";
 
 const DropzoneThemeExtension = Dropzone.extend({
   classNames: {
-    inner: 'flex flex-col justify-center items-center border-4 border-dashed border-orange-5 rounded-lg my-2 p-2 cursor-pointer',
+    inner: 'flex flex-col justify-center items-center bg-neutral-2 hover:bg-neutral-3 border-4 border-dashed border-orange-5 rounded-lg my-2 p-2 cursor-pointer',
   }
 });
 

--- a/src/styles/components/SelectThemeExtension.ts
+++ b/src/styles/components/SelectThemeExtension.ts
@@ -3,7 +3,7 @@ import { Select } from "@mantine/core";
 const SelectThemeExtension = Select.extend({
   classNames: {
     wrapper: 'max-w-80',
-    input: 'border-blue border-2 px-0 py-2.5 rounded-sm max-h-30 overflow-y-scroll',
+    input: 'border-blue border-2 rounded-sm max-h-30 overflow-y-scroll',
     dropdown: "rounded-sm border-neutral border p-0",
     option: "hover:bg-neutral-3 active:bg-neutral-4 rounded-none nth-2:rounded-t-sm last:rounded-b-sm not-last:border-b not-last:border-b-neutral-4",
   }

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -1,0 +1,4 @@
+export function toNormalCase(str: string) {
+  str = str.trim();
+  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+}


### PR DESCRIPTION
- Created UploadUsersCsvModal to allow admin users to bulk create user accounts
  - Allows user to select which type of CSV (family or employee) they want to upload
  - Once file is uploaded, it is immediately parsed and the results are shown to the user
    - Uses Zod for validation
    - If a single record fails validation, an error is thrown and the user is asked to correct & reupload the csv
  - For employees, the user can change the roles of the users about to be created since the csv file does not differentiate between role
    - Since family members (campers + parents) are differentiated int the csv file, their roles can't be changed before uploading
- Modified Dropzone theme extension
- Modified Select theme extension

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified CSV upload modal for bulk import of families or employees, with per-employee role selection, parsed preview badges, loaders, and error states.

* **Improvements**
  * CSV parsing now validates required columns and records, returning clearer line-numbered error messages.
  * Normalized name formatting for uploaded data.

* **Bug Fixes**
  * Tighter authorization check for employee CSV uploads.

* **Style**
  * Enhanced Dropzone visuals and refined upload area text alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->