### PR TITLE
bugfix(users): update Firestore doc with uid during user registration

### DIFF
--- a/functions/src/features/accountManagement.ts
+++ b/functions/src/features/accountManagement.ts
@@ -18,6 +18,9 @@ const checkAllowlist = beforeUserCreated(async (event) => {
 
   try {
     const user = await getUserDocByEmail(email);
+    if (user.uid) {
+      throw new HttpsError("failed-precondition", "An user with this email already exists");
+    }
     await updateUserDoc(user.id, { uid: event.data.uid });
     return {
       customClaims: (user.role === "ADMIN" ?

--- a/functions/src/features/accountManagement.ts
+++ b/functions/src/features/accountManagement.ts
@@ -2,39 +2,29 @@ import { CallableRequest, HttpsError, onCall } from "firebase-functions/https";
 import { beforeUserCreated } from "firebase-functions/v2/identity";
 import { z } from "zod";
 import { adminAuth } from "../config/firebaseAdminConfig";
-import { getUserDocByEmail, getUserDocById, deleteUserDoc, updateUserDoc } from "../data/firestore/users";
+import { getUserDocByEmail, getUserDocById, deleteUserDoc } from "../data/firestore/users";
 import { CustomClaims } from "@/auth/types/clientAuthTypes";
 import { isAdmin } from "@/types/users/userTypeGuards";
 
 const checkAllowlist = beforeUserCreated(async (event) => {
-  if (!event.data) {
-    throw new HttpsError("invalid-argument", "Missing user data");
-  }
-
-  const email = event.data.email;
+  const email = event.data?.email;
   if (!email) {
     throw new HttpsError("failed-precondition", "User has no email address");
   }
 
   try {
     const user = await getUserDocByEmail(email);
-    if (user.uid) {
-      throw new HttpsError("failed-precondition", "User already has an account");
+    return {
+      customClaims: (user.role === "ADMIN" ?
+        {
+          role: "ADMIN",
+          campminderId: user.id,
+          isSuperAdmin: false
+        } : {
+          role: user.role,
+          campminderId: user.id
+        }) satisfies CustomClaims
     }
-
-    const customClaims: CustomClaims = (user.role === "ADMIN" ?
-      {
-        role: "ADMIN",
-        campminderId: user.id,
-        isSuperAdmin: false
-      } : {
-        role: user.role,
-        campminderId: user.id
-      }) satisfies CustomClaims
-    const uid = event.data.uid;
-    await adminAuth.setCustomUserClaims(uid, customClaims);
-    await updateUserDoc(user.id, { uid });
-    
   } catch (error: unknown) {
     if (error instanceof Error) {
       if (error.message === "No user with email found") {

--- a/functions/src/features/accountManagement.ts
+++ b/functions/src/features/accountManagement.ts
@@ -2,29 +2,39 @@ import { CallableRequest, HttpsError, onCall } from "firebase-functions/https";
 import { beforeUserCreated } from "firebase-functions/v2/identity";
 import { z } from "zod";
 import { adminAuth } from "../config/firebaseAdminConfig";
-import { getUserDocByEmail, getUserDocById, deleteUserDoc } from "../data/firestore/users";
+import { getUserDocByEmail, getUserDocById, deleteUserDoc, updateUserDoc } from "../data/firestore/users";
 import { CustomClaims } from "@/auth/types/clientAuthTypes";
 import { isAdmin } from "@/types/users/userTypeGuards";
 
 const checkAllowlist = beforeUserCreated(async (event) => {
-  const email = event.data?.email;
+  if (!event.data) {
+    throw new HttpsError("invalid-argument", "Missing user data");
+  }
+
+  const email = event.data.email;
   if (!email) {
     throw new HttpsError("failed-precondition", "User has no email address");
   }
 
   try {
     const user = await getUserDocByEmail(email);
-    return {
-      customClaims: (user.role === "ADMIN" ?
-        {
-          role: "ADMIN",
-          campminderId: user.id,
-          isSuperAdmin: false
-        } : {
-          role: user.role,
-          campminderId: user.id
-        }) satisfies CustomClaims
+    if (user.uid) {
+      throw new HttpsError("failed-precondition", "User already has an account");
     }
+
+    const customClaims: CustomClaims = (user.role === "ADMIN" ?
+      {
+        role: "ADMIN",
+        campminderId: user.id,
+        isSuperAdmin: false
+      } : {
+        role: user.role,
+        campminderId: user.id
+      }) satisfies CustomClaims
+    const uid = event.data.uid;
+    await adminAuth.setCustomUserClaims(uid, customClaims);
+    await updateUserDoc(user.id, { uid });
+    
   } catch (error: unknown) {
     if (error instanceof Error) {
       if (error.message === "No user with email found") {

--- a/functions/src/features/accountManagement.ts
+++ b/functions/src/features/accountManagement.ts
@@ -2,18 +2,23 @@ import { CallableRequest, HttpsError, onCall } from "firebase-functions/https";
 import { beforeUserCreated } from "firebase-functions/v2/identity";
 import { z } from "zod";
 import { adminAuth } from "../config/firebaseAdminConfig";
-import { getUserDocByEmail, getUserDocById, deleteUserDoc } from "../data/firestore/users";
+import { getUserDocByEmail, getUserDocById, deleteUserDoc, updateUserDoc } from "../data/firestore/users";
 import { CustomClaims } from "@/auth/types/clientAuthTypes";
 import { isAdmin } from "@/types/users/userTypeGuards";
 
 const checkAllowlist = beforeUserCreated(async (event) => {
-  const email = event.data?.email;
+  if (!event.data) {
+    throw new HttpsError("invalid-argument", "Missing user data");
+  }
+
+  const email = event.data.email;
   if (!email) {
     throw new HttpsError("failed-precondition", "User has no email address");
   }
 
   try {
     const user = await getUserDocByEmail(email);
+    await updateUserDoc(user.id, { uid: event.data.uid });
     return {
       customClaims: (user.role === "ADMIN" ?
         {


### PR DESCRIPTION
- `uid` field was not being written to a user's Firestore document during registration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation during user account creation with improved error messages for missing or invalid data
  * Strengthened data integrity by ensuring authentication records are consistently linked to user accounts during registration

* **Improvements**
  * Increased reliability and consistency of the user creation process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->