### PR TITLE
bugfix(deployment): fix Apps Script glob pattern

### DIFF
--- a/apps-script/package.json
+++ b/apps-script/package.json
@@ -2,7 +2,7 @@
   "name": "apps-script",
   "scripts": {
     "lint": "eslint src",
-    "build": "rm -rf dist && esbuild src/*.ts --bundle --outdir=dist --format=esm --global-name=globalThis --target=es6 && cp src/appsscript.json dist/appsscript.json",
+    "build": "rm -rf dist && esbuild src/**/*.ts --bundle --outdir=dist --format=esm --global-name=globalThis --target=es6 && cp src/appsscript.json dist/appsscript.json",
     "deploy": "npm run build && clasp push --force"
   },
   "devDependencies": {


### PR DESCRIPTION
- Apps Script code in nested folders under `src` was not being compiled to JavaScript and pushed to the Apps Script project
  - Fixed this by adding a recursive wildcard to the glob pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build process now supports TypeScript files across nested directory structures, enabling more flexible source code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->