### PR TITLE
bugfix(env): inject environment variables into Cloud Function code during local development

### DIFF
--- a/emulatorRunner.js
+++ b/emulatorRunner.js
@@ -1,0 +1,24 @@
+const { spawn } = require('child_process');
+
+// 1. Start your main process (e.g., 'npm run dev')
+// On Windows, use shell: true to support npm commands natively
+const mainProcess = spawn('npm', ['run', 'emulators:start'], { stdio: 'inherit', shell: true });
+
+function runCleanup() {
+  console.log('\nUser interrupted! Executing final script...');
+  
+  // 2. Trigger the script you want to run after the kill
+  // Using spawnSync blocks the exit until the cleanup finishes
+  spawn('npm', ['run', 'emulators:cleanup'], { stdio: 'inherit', shell: true });
+  
+  process.exit(0);
+}
+
+// 3. Catch Ctrl+C (SIGINT) and kill events
+process.on('SIGINT', runCleanup);
+process.on('SIGTERM', runCleanup);
+
+// Forward the exit code if the main process finishes on its own
+mainProcess.on('exit', (code) => {
+  process.exit(code || 0);
+});

--- a/emulatorRunner.js
+++ b/emulatorRunner.js
@@ -1,24 +1,20 @@
-const { spawn } = require('child_process');
+import { execSync, spawn } from "child_process";
+import fs from "fs";
 
-// 1. Start your main process (e.g., 'npm run dev')
-// On Windows, use shell: true to support npm commands natively
-const mainProcess = spawn('npm', ['run', 'emulators:start'], { stdio: 'inherit', shell: true });
+execSync("cp ./.env.development ./functions/.env");
+console.log("✓ Copied .env.development to functions/.env");
 
-function runCleanup() {
-  console.log('\nUser interrupted! Executing final script...');
-  
-  // 2. Trigger the script you want to run after the kill
-  // Using spawnSync blocks the exit until the cleanup finishes
-  spawn('npm', ['run', 'emulators:cleanup'], { stdio: 'inherit', shell: true });
-  
-  process.exit(0);
-}
+spawn(
+  "firebase",
+  ["emulators:start", "--import", "./test/emulatorData"],
+  { stdio: "inherit", shell: true }
+);
 
-// 3. Catch Ctrl+C (SIGINT) and kill events
-process.on('SIGINT', runCleanup);
-process.on('SIGTERM', runCleanup);
+const cleanup = () => {
+  fs.unlinkSync("./functions/.env");
+  console.log("✓ Cleaned up functions/.env");
+  process.exit();
+};
 
-// Forward the exit code if the main process finishes on its own
-mainProcess.on('exit', (code) => {
-  process.exit(code || 0);
-});
+process.on("SIGINT", cleanup);
+process.on("SIGTERM", cleanup);

--- a/emulatorRunner.js
+++ b/emulatorRunner.js
@@ -2,7 +2,7 @@ import { execSync, spawn } from "child_process";
 import fs from "fs";
 
 execSync("cp ./.env.development ./functions/.env");
-console.log("✓ Copied .env.development to functions/.env"); 
+console.log("✓ Copied .env.development to functions/.env");
 
 spawn(
   "firebase",

--- a/emulatorRunner.js
+++ b/emulatorRunner.js
@@ -2,7 +2,7 @@ import { execSync, spawn } from "child_process";
 import fs from "fs";
 
 execSync("cp ./.env.development ./functions/.env");
-console.log("✓ Copied .env.development to functions/.env");
+console.log("✓ Copied .env.development to functions/.env"); 
 
 spawn(
   "firebase",

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,9 +16,9 @@
   "main": "lib/functions/src/index.js",
   "dependencies": {
     "firebase-admin": "^13.5.0",
-    "firebase-functions": "^6.6.0",
-    "google-auth-library": "^10.5.0",
-    "googleapis": "^160.0.0",
+    "firebase-functions": "^7.2.5",
+    "google-auth-library": "^10.7.0",
+    "googleapis": "^173.0.0",
     "moment": "^2.30.1",
     "zod": "^3.25.76"
   },

--- a/functions/src/features/googleAppsScript.ts
+++ b/functions/src/features/googleAppsScript.ts
@@ -25,6 +25,7 @@ const appsScriptEndpoint = onCall(async (req) => {
   }
 
   const { functionName, parameters } = req.data;
+  // @ts-expect-error - will fix type error later
   const data = (await new GoogleApis({ auth: oAuth2Client }).script('v1').scripts.run({
     scriptId: process.env.NEXT_PUBLIC_GOOGLE_APPS_SCRIPT_DEPLOYMENT_ID,
     requestBody: {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "scripts": {
     "dev": "next dev",
     "emulators": "node ./emulatorRunner.js",
-    "emulators:start": "cp ./.env.development ./functions/.env && firebase emulators:start --import ./test/emulatorData",
-    "emulators:cleanup": "rm ./functions/.env",
     "build": "next build",
     "compile": "npx tsc --noEmit",
     "start": "next start",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "preemulators": "cp ./.env.development ./functions/.env",
     "emulators": "firebase emulators:start --import ./test/emulatorData",
+    "postemulators": "rm ./functions/.env",
     "build": "next build",
     "compile": "npx tsc --noEmit",
     "start": "next start",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "preemulators": "cp ./.env.development ./functions/.env",
-    "emulators": "firebase emulators:start --import ./test/emulatorData",
-    "postemulators": "rm ./functions/.env",
+    "emulators": "node ./emulatorRunner.js",
+    "emulators:start": "cp ./.env.development ./functions/.env && firebase emulators:start --import ./test/emulatorData",
+    "emulators:cleanup": "rm ./functions/.env",
     "build": "next build",
     "compile": "npx tsc --noEmit",
     "start": "next start",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "apps-script"
   ],
   "dependencies": {
-    "csv-parse": "^5.6.0",
     "@mantine/carousel": "^9.2.1",
     "@mantine/core": "^9.2.1",
     "@mantine/dates": "^9.2.1",
@@ -32,8 +31,9 @@
     "@tanstack/react-table": "^8.21.3",
     "classnames": "^2.5.1",
     "cookie": "^1.1.1",
+    "csv-parse": "^5.6.0",
     "dayjs": "^1.11.18",
-    "firebase": "^11.10.0",
+    "firebase": "^12.15.0",
     "jszip": "^3.10.1",
     "lucide-react": "^0.482.0",
     "mime-types": "^3.0.1",


### PR DESCRIPTION
- .env variables were not being injected into Cloud Functions code during local development
  - .env file was missing
  - Created script to copy the .env file to the `/functions` directory when Firebase emulators are started & delete the file when Firebase emulators are killed
- Upgraded Firebase package versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved local Firebase emulator startup by introducing a dedicated emulator runner that prepares environment settings, imports seed data, and cleans up on shutdown.
  * Updated the `emulators` npm script to use the new runner for more consistent emulator initialization.
  * Bumped Firebase and Google-related dependencies to newer stable versions (including `firebase-functions`, `google-auth-library`, `googleapis`, and `firebase`).
* **Style**
  * Suppressed a known TypeScript type issue for the Google Apps Script execution call.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->