### PR TITLE
feat(scheduling): create section schedule documents for scheduling sections

### DIFF
--- a/src/components/EditSectionModal.tsx
+++ b/src/components/EditSectionModal.tsx
@@ -99,10 +99,10 @@ export function EditSectionModalContent(props: EditSectionModalContentProps) {
         {
           sessionId: section.sessionId,
           sectionId: section.id,
-          name,
-          startDate: moment(dateRange[0]),
-          endDate: moment(dateRange[1]),
-          type: scheduleType,
+          name: section.name !== name ? name : undefined,
+          startDate: moment(dateRange[0]).isSame(section.startDate) ? undefined : moment(dateRange[0]),
+          endDate: moment(dateRange[1]).isSame(section.endDate) ? undefined : moment(dateRange[1]),
+          type: scheduleType !== section.type ? scheduleType : undefined,
         },
         {
           onSuccess: () => modals.closeAll(),

--- a/src/data/firestore/sectionSchedules.ts
+++ b/src/data/firestore/sectionSchedules.ts
@@ -1,5 +1,5 @@
 import { SectionSchedule } from "@/types/scheduling/schedulingTypes";
-import { SectionDoc, SectionScheduleDoc } from "./types/documents";
+import { SectionScheduleDoc } from "./types/documents";
 import { collection, CollectionReference, doc, DocumentReference, DocumentSnapshot, QueryDocumentSnapshot, Transaction, UpdateData, WithFieldValue, WriteBatch } from "firebase/firestore";
 import { deleteDoc, executeQuery, getDoc, setDoc, updateDoc } from "./firestoreClientOperations";
 import { db } from "@/config/firebase";

--- a/src/data/firestore/sectionSchedules.ts
+++ b/src/data/firestore/sectionSchedules.ts
@@ -1,9 +1,10 @@
 import { SectionSchedule } from "@/types/scheduling/schedulingTypes";
-import { SectionScheduleDoc } from "./types/documents";
-import { doc, DocumentReference, DocumentSnapshot, QueryDocumentSnapshot, Transaction } from "firebase/firestore";
-import { getDoc } from "./firestoreClientOperations";
+import { SectionDoc, SectionScheduleDoc } from "./types/documents";
+import { collection, CollectionReference, doc, DocumentReference, DocumentSnapshot, QueryDocumentSnapshot, Transaction, UpdateData, WithFieldValue, WriteBatch } from "firebase/firestore";
+import { deleteDoc, executeQuery, getDoc, setDoc, updateDoc } from "./firestoreClientOperations";
 import { db } from "@/config/firebase";
 import { RootLevelCollection, SectionsSubcollection, SessionsSubcollection } from "./types/collections";
+import { FirestoreQueryOptions } from "./types/queries";
 
 function fromFirestore(snapshot: DocumentSnapshot<SectionScheduleDoc, SectionScheduleDoc> | QueryDocumentSnapshot<SectionScheduleDoc, SectionScheduleDoc>): SectionSchedule {
   if (!snapshot.exists()) { throw Error("Document not found"); };
@@ -14,7 +15,32 @@ function fromFirestore(snapshot: DocumentSnapshot<SectionScheduleDoc, SectionSch
   }
 }
 
-export async function getSectionSchedule(sessionId: string, sectionId: string, transaction?: Transaction): Promise<SectionSchedule> {
-  const snapshot = await getDoc<SectionScheduleDoc>(doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.SECTIONS, sectionId, SectionsSubcollection.SCHEDULE, SectionsSubcollection.SCHEDULE) as DocumentReference<SectionScheduleDoc, SectionScheduleDoc>, transaction);
+function getSectionScheduleDocRef(sessionId: string, sectionId: string): DocumentReference<SectionScheduleDoc, SectionScheduleDoc> {
+  return doc(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.SECTIONS, sectionId, SectionsSubcollection.SCHEDULE, SectionsSubcollection.SCHEDULE) as DocumentReference<SectionScheduleDoc, SectionScheduleDoc>;
+}
+
+function getSectionScheduleCollectionRef(sessionId: string, sectionId: string): CollectionReference<SectionScheduleDoc, SectionScheduleDoc> {
+  return collection(db, RootLevelCollection.SESSIONS, sessionId, SessionsSubcollection.SECTIONS, sectionId, SectionsSubcollection.SCHEDULE) as CollectionReference<SectionScheduleDoc, SectionScheduleDoc>;
+}
+
+export async function getSectionScheduleDoc(sessionId: string, sectionId: string, transaction?: Transaction): Promise<SectionSchedule> {
+  const snapshot = await getDoc<SectionScheduleDoc>(getSectionScheduleDocRef(sessionId, sectionId), transaction);
   return fromFirestore(snapshot);
+}
+
+export async function listSectionScheduleDocs(sessionId: string, sectionId: string, firestoreQueryOptions: FirestoreQueryOptions<SectionScheduleDoc> = {}): Promise<SectionSchedule[]> {
+  const snapshots = await executeQuery<SectionScheduleDoc>(getSectionScheduleCollectionRef(sessionId, sectionId), firestoreQueryOptions);
+  return snapshots.map(fromFirestore);
+}
+
+export async function setSectionScheduleDoc(sessionId: string, sectionId: string, sectionSchedule: WithFieldValue<SectionScheduleDoc>, instance?: Transaction | WriteBatch): Promise<void> {
+  await setDoc<SectionScheduleDoc>(getSectionScheduleDocRef(sessionId, sectionId), sectionSchedule, { instance });
+}
+
+export async function updateSectionScheduleDoc(sessionId: string, sectionId: string, updates: UpdateData<SectionScheduleDoc>, instance?: Transaction | WriteBatch): Promise<void> {
+  await updateDoc<SectionScheduleDoc>(getSectionScheduleDocRef(sessionId, sectionId), updates, instance);
+}
+
+export async function deleteSectionScheduleDoc(sessionId: string, sectionId: string, instance?: Transaction | WriteBatch): Promise<void> {
+  await deleteDoc<SectionScheduleDoc>(getSectionScheduleDocRef(sessionId, sectionId), instance);
 }

--- a/src/hooks/schedules/useSectionSchedule.ts
+++ b/src/hooks/schedules/useSectionSchedule.ts
@@ -1,9 +1,9 @@
-import { getSectionSchedule } from "@/data/firestore/sectionSchedules";
+import { getSectionScheduleDoc } from "@/data/firestore/sectionSchedules";
 import { skipToken, useQuery } from "@tanstack/react-query";
 
 export default function useSectionSchedule(sessionId: string | undefined, sectionId: string | undefined) {
   return useQuery({
     queryKey: ['sessions', sessionId, 'sections', sectionId, 'schedule'],
-    queryFn: sessionId && sectionId ? (() => getSectionSchedule(sessionId, sectionId)) : skipToken,
+    queryFn: sessionId && sectionId ? (() => getSectionScheduleDoc(sessionId, sectionId)) : skipToken,
   });
 }

--- a/src/hooks/sections/useCreateSection.ts
+++ b/src/hooks/sections/useCreateSection.ts
@@ -1,7 +1,11 @@
+import { db } from "@/config/firebase";
 import { createSectionDoc } from "@/data/firestore/sections";
+import { setSectionScheduleDoc } from "@/data/firestore/sectionSchedules";
+import { SectionScheduleDoc } from "@/data/firestore/types/documents";
+import { getBlockIdFromNum } from "@/types/scheduling/schedulingUtils";
 import { SectionType } from "@/types/sessions/sessionTypes";
 import { useMutation } from "@tanstack/react-query";
-import { Timestamp } from "firebase/firestore";
+import { runTransaction, Timestamp, Transaction } from "firebase/firestore";
 import { Moment } from "moment";
 
 interface CreateSectionRequest {
@@ -12,14 +16,40 @@ interface CreateSectionRequest {
   type: SectionType;
 }
 
+const DEFAULT_NUMBER_BLOCKS = 5;
+
 async function createSection(req: CreateSectionRequest) {
   const { sessionId, ...rest } = req;
-  await createSectionDoc(sessionId, {
-    name: rest.name,
-    startDate: Timestamp.fromDate(rest.startDate.clone().startOf('day').toDate()),
-    endDate: Timestamp.fromDate(rest.endDate.clone().endOf('day').toDate()),
+  if (rest.type === "COMMON") {
+    await createSectionDoc(sessionId, {
+      name: rest.name,
+      startDate: Timestamp.fromDate(rest.startDate.clone().startOf('day').toDate()),
+      endDate: Timestamp.fromDate(rest.endDate.clone().endOf('day').toDate()),
+      type: rest.type,
+    });
+    return;
+  }
+
+  const sectionScheduleDoc: SectionScheduleDoc = {
     type: rest.type,
-    publishedAt: null,
+    blocks: {},
+    alternatePeriodsOff: {}
+  };
+  for (let i = 0; i < DEFAULT_NUMBER_BLOCKS; i++) {
+    sectionScheduleDoc.blocks[getBlockIdFromNum(i)] = {
+      activities: [],
+      periodsOff: []
+    }
+  }
+  await runTransaction(db, async (transaction: Transaction) => {
+    const sectionId = await createSectionDoc(sessionId, {
+      name: rest.name,
+      startDate: Timestamp.fromDate(rest.startDate.clone().startOf('day').toDate()),
+      endDate: Timestamp.fromDate(rest.endDate.clone().endOf('day').toDate()),
+      type: rest.type,
+      publishedAt: null,
+    }, transaction);
+    await setSectionScheduleDoc(sessionId, sectionId, sectionScheduleDoc);
   })
 }
 

--- a/src/hooks/sections/useCreateSection.ts
+++ b/src/hooks/sections/useCreateSection.ts
@@ -36,7 +36,7 @@ async function createSection(req: CreateSectionRequest) {
       type: rest.type,
       publishedAt: null,
     }, transaction);
-    await setSectionScheduleDoc(sessionId, sectionId, sectionScheduleDoc);
+    await setSectionScheduleDoc(sessionId, sectionId, sectionScheduleDoc, transaction);
   })
 }
 

--- a/src/hooks/sections/useCreateSection.ts
+++ b/src/hooks/sections/useCreateSection.ts
@@ -2,7 +2,7 @@ import { db } from "@/config/firebase";
 import { createSectionDoc } from "@/data/firestore/sections";
 import { setSectionScheduleDoc } from "@/data/firestore/sectionSchedules";
 import { SectionScheduleDoc } from "@/data/firestore/types/documents";
-import { getBlockIdFromNum } from "@/types/scheduling/schedulingUtils";
+import { DEFAULT_NUMBER_BLOCKS, getBlockIdFromNum, getEmptySectionScheduleDoc } from "@/types/scheduling/schedulingUtils";
 import { SectionType } from "@/types/sessions/sessionTypes";
 import { useMutation } from "@tanstack/react-query";
 import { runTransaction, Timestamp, Transaction } from "firebase/firestore";
@@ -16,8 +16,6 @@ interface CreateSectionRequest {
   type: SectionType;
 }
 
-const DEFAULT_NUMBER_BLOCKS = 5;
-
 async function createSection(req: CreateSectionRequest) {
   const { sessionId, ...rest } = req;
   if (rest.type === "COMMON") {
@@ -30,17 +28,7 @@ async function createSection(req: CreateSectionRequest) {
     return;
   }
 
-  const sectionScheduleDoc: SectionScheduleDoc = {
-    type: rest.type,
-    blocks: {},
-    alternatePeriodsOff: {}
-  };
-  for (let i = 0; i < DEFAULT_NUMBER_BLOCKS; i++) {
-    sectionScheduleDoc.blocks[getBlockIdFromNum(i)] = {
-      activities: [],
-      periodsOff: []
-    }
-  }
+  const sectionScheduleDoc = getEmptySectionScheduleDoc(rest.type, DEFAULT_NUMBER_BLOCKS);
   await runTransaction(db, async (transaction: Transaction) => {
     const sectionId = await createSectionDoc(sessionId, {
       name: rest.name,

--- a/src/hooks/sections/useCreateSection.ts
+++ b/src/hooks/sections/useCreateSection.ts
@@ -1,8 +1,7 @@
 import { db } from "@/config/firebase";
 import { createSectionDoc } from "@/data/firestore/sections";
 import { setSectionScheduleDoc } from "@/data/firestore/sectionSchedules";
-import { SectionScheduleDoc } from "@/data/firestore/types/documents";
-import { DEFAULT_NUMBER_BLOCKS, getBlockIdFromNum, getEmptySectionScheduleDoc } from "@/types/scheduling/schedulingUtils";
+import { DEFAULT_NUMBER_BLOCKS, getEmptySectionScheduleDoc } from "@/types/scheduling/schedulingUtils";
 import { SectionType } from "@/types/sessions/sessionTypes";
 import { useMutation } from "@tanstack/react-query";
 import { runTransaction, Timestamp, Transaction } from "firebase/firestore";

--- a/src/hooks/sections/useUpdateSection.ts
+++ b/src/hooks/sections/useUpdateSection.ts
@@ -1,7 +1,7 @@
 import { db } from "@/config/firebase";
 import { updateSectionDoc } from "@/data/firestore/sections";
 import { deleteSectionScheduleDoc, setSectionScheduleDoc } from "@/data/firestore/sectionSchedules";
-import { SchedulingSectionDoc, SectionDoc } from "@/data/firestore/types/documents";
+import { SchedulingSectionDoc } from "@/data/firestore/types/documents";
 import { DEFAULT_NUMBER_BLOCKS, getEmptySectionScheduleDoc } from "@/types/scheduling/schedulingUtils";
 import { SectionType } from "@/types/sessions/sessionTypes";
 import { useMutation } from "@tanstack/react-query";

--- a/src/hooks/sections/useUpdateSection.ts
+++ b/src/hooks/sections/useUpdateSection.ts
@@ -43,11 +43,6 @@ async function updateSection(req: UpdateSectionRequest) {
         endDate: updates.endDate ? Timestamp.fromDate(updates.endDate.clone().endOf('day').toDate()) : undefined,
       });
   }
-
-
-  await updateSectionDoc(sessionId, sectionId, {
-    type: "BUNK-JAMBO",
-  });
 }
 
 export default function useUpdateSection() {

--- a/src/hooks/sections/useUpdateSection.ts
+++ b/src/hooks/sections/useUpdateSection.ts
@@ -1,7 +1,11 @@
+import { db } from "@/config/firebase";
 import { updateSectionDoc } from "@/data/firestore/sections";
+import { deleteSectionScheduleDoc, setSectionScheduleDoc } from "@/data/firestore/sectionSchedules";
+import { SchedulingSectionDoc, SectionDoc } from "@/data/firestore/types/documents";
+import { DEFAULT_NUMBER_BLOCKS, getEmptySectionScheduleDoc } from "@/types/scheduling/schedulingUtils";
 import { SectionType } from "@/types/sessions/sessionTypes";
 import { useMutation } from "@tanstack/react-query";
-import { deleteField, Timestamp } from "firebase/firestore";
+import { deleteField, runTransaction, Timestamp, Transaction, UpdateData } from "firebase/firestore";
 import { Moment } from "moment";
 
 interface UpdateSectionRequest {
@@ -17,23 +21,35 @@ async function updateSection(req: UpdateSectionRequest) {
   const { sessionId, sectionId, ...updates } = req;
   switch (updates.type) {
     case "COMMON":
-      await updateSectionDoc(sessionId, sectionId, {
-        name: updates.name,
-        startDate: updates.startDate ? Timestamp.fromDate(updates.startDate.clone().startOf('day').toDate()) : undefined,
-        endDate: updates.endDate ? Timestamp.fromDate(updates.endDate.clone().endOf('day').toDate()) : undefined,
-        type: "COMMON",
-        publishedAt: deleteField()
+      await runTransaction(db, async (transaction: Transaction) => {
+        await Promise.all([
+          updateSectionDoc(sessionId, sectionId, {
+            name: updates.name,
+            startDate: updates.startDate ? Timestamp.fromDate(updates.startDate.clone().startOf('day').toDate()) : undefined,
+            endDate: updates.endDate ? Timestamp.fromDate(updates.endDate.clone().endOf('day').toDate()) : undefined,
+            type: "COMMON",
+            publishedAt: deleteField()
+          }, transaction),
+          deleteSectionScheduleDoc(sessionId, sectionId, transaction)
+        ]);
       });
       break;
     case "BUNDLE":
     case "BUNK-JAMBO":
     case "NON-BUNK-JAMBO":
-      await updateSectionDoc(sessionId, sectionId, {
+      const sectionUpdates: UpdateData<SchedulingSectionDoc> = {
         name: updates.name,
         startDate: updates.startDate ? Timestamp.fromDate(updates.startDate.clone().startOf('day').toDate()) : undefined,
         endDate: updates.endDate ? Timestamp.fromDate(updates.endDate.clone().endOf('day').toDate()) : undefined,
         type: updates.type,
         publishedAt: null
+      }
+      const sectionScheduleDoc = getEmptySectionScheduleDoc(updates.type, DEFAULT_NUMBER_BLOCKS);
+      await runTransaction(db, async (transaction: Transaction) => {
+        await Promise.all([
+          updateSectionDoc(sessionId, sectionId, sectionUpdates, transaction),
+          setSectionScheduleDoc(sessionId, sectionId, sectionScheduleDoc, transaction)
+        ])
       });
       break;
     default:

--- a/src/hooks/sections/useUpdateSection.ts
+++ b/src/hooks/sections/useUpdateSection.ts
@@ -20,7 +20,7 @@ interface UpdateSectionRequest {
 async function updateSection(req: UpdateSectionRequest) {
   const { sessionId, sectionId, ...updates } = req;
   switch (updates.type) {
-    case "COMMON":
+    case "COMMON": {
       await runTransaction(db, async (transaction: Transaction) => {
         await Promise.all([
           updateSectionDoc(sessionId, sectionId, {
@@ -34,9 +34,10 @@ async function updateSection(req: UpdateSectionRequest) {
         ]);
       });
       break;
+    }
     case "BUNDLE":
     case "BUNK-JAMBO":
-    case "NON-BUNK-JAMBO":
+    case "NON-BUNK-JAMBO": {
       const sectionUpdates: UpdateData<SchedulingSectionDoc> = {
         name: updates.name,
         startDate: updates.startDate ? Timestamp.fromDate(updates.startDate.clone().startOf('day').toDate()) : undefined,
@@ -52,12 +53,14 @@ async function updateSection(req: UpdateSectionRequest) {
         ])
       });
       break;
-    default:
+    }
+    default: {
       await updateSectionDoc(sessionId, sectionId, {
         name: updates.name,
         startDate: updates.startDate ? Timestamp.fromDate(updates.startDate.clone().startOf('day').toDate()) : undefined,
         endDate: updates.endDate ? Timestamp.fromDate(updates.endDate.clone().endOf('day').toDate()) : undefined,
       });
+    }
   }
 }
 

--- a/src/types/scheduling/schedulingUtils.ts
+++ b/src/types/scheduling/schedulingUtils.ts
@@ -1,5 +1,7 @@
+import { SectionScheduleDoc } from "@/data/firestore/types/documents";
 import { isBundleActivity } from "@/types/scheduling/schedulingTypeGuards";
 import { Activity } from "@/types/scheduling/schedulingTypes";
+import { SchedulingSectionType } from "../sessions/sessionTypes";
 
 export function getActivityName(activity: Activity): string {
   return isBundleActivity(activity) ? `${activity.programAreaId}: ${activity.name}` : activity.name;
@@ -10,3 +12,20 @@ export function getBlockIdFromNum(num: number) {
   if (num < 0 || num >= 10) throw Error("Invalid block number");
   return String.fromCharCode(num + CAPITAL_A_CHAR_CODE);
 }
+
+export function getEmptySectionScheduleDoc(type: SchedulingSectionType, numBlocks: number) {
+  const sectionScheduleDoc: SectionScheduleDoc = {
+    type,
+    blocks: {},
+    alternatePeriodsOff: {}
+  }
+  for (let i = 0; i < numBlocks; i++) {
+    sectionScheduleDoc.blocks[getBlockIdFromNum(i)] = {
+      activities: [],
+      periodsOff: []
+    }
+  }
+  return sectionScheduleDoc;
+}
+
+export const DEFAULT_NUMBER_BLOCKS = 5;

--- a/test/emulatorData/auth_export/config.json
+++ b/test/emulatorData/auth_export/config.json
@@ -1,0 +1,1 @@
+{"signIn":{"allowDuplicateEmails":false},"emailPrivacyConfig":{"enableImprovedEmailPrivacy":false}}

--- a/test/emulatorData/storage_export/buckets.json
+++ b/test/emulatorData/storage_export/buckets.json
@@ -1,0 +1,7 @@
+{
+  "buckets": [
+    {
+      "id": "camp-starfish.firebasestorage.app"
+    }
+  ]
+}


### PR DESCRIPTION
- Created section schedule documents during section creation
  - Section schedules are only created for scheduling sections (bundles + jamborees), not for common sections
- When section type is changed, the following happens:
  - When the section is changed to be a common section, the section schedule doc is deleted
  - When the section is changed to be a scheduling section, an empty schedule is created
- Created Firestore wrappers for working with section schedules
- Created utility functions to help with schedule creation
- Deleted accidental `camp-starfish` folder/file from #38
- Readded emualtor config files that were deleted in #38 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Section schedules now support viewing, creating, updating, and removing schedule data more reliably.
  * Section creation and updates now handle different section types more consistently, including automatic schedule setup where needed.

* **Bug Fixes**
  * Improved section date handling so saved dates stay within the intended day range.
  * Reduced the chance of incomplete section/schedule updates by making related changes happen together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->