### PR TITLE
bugfix(users): properly extract user IDs from request object

### DIFF
--- a/functions/src/features/userCsvProcessing.ts
+++ b/functions/src/features/userCsvProcessing.ts
@@ -25,7 +25,7 @@ export const processFamilyCsv = onCall(async (req) => {
   }))
 
   await adminDb.runTransaction(async (transaction) => {
-    const allIds: number[] = [...Object.keys(campers), ...Object.keys(parents)].map(id => parseInt(id));
+    const allIds: number[] = [...campers.map(camper => camper.id), ...parents.map(parent => parent.id)];
     const existingUsers = await batchGetUserDocs(allIds);
 
     const { trueGroup: existingCamperUpdates, falseGroup: newCampers } = partition(Object.values(campers), (camper) => existingUsers.some(user => user.id === camper.id));

--- a/functions/src/features/userCsvProcessing.ts
+++ b/functions/src/features/userCsvProcessing.ts
@@ -28,8 +28,8 @@ export const processFamilyCsv = onCall(async (req) => {
     const allIds: number[] = [...campers.map(camper => camper.id), ...parents.map(parent => parent.id)];
     const existingUsers = await batchGetUserDocs(allIds);
 
-    const { trueGroup: existingCamperUpdates, falseGroup: newCampers } = partition(Object.values(campers), (camper) => existingUsers.some(user => user.id === camper.id));
-    const { trueGroup: existingParentUpdates, falseGroup: newParents } = partition(Object.values(parents), (parent) => existingUsers.some(user => user.id === parent.id));
+    const { trueGroup: existingCamperUpdates, falseGroup: newCampers } = partition(campers, (camper) => existingUsers.some(user => user.id === camper.id));
+    const { trueGroup: existingParentUpdates, falseGroup: newParents } = partition(parents, (parent) => existingUsers.some(user => user.id === parent.id));
 
     const promises = [
       newCampers.map((camper) => {
@@ -51,7 +51,7 @@ export const processFamilyCsv = onCall(async (req) => {
         const existingCamper = existingUsers.find(camper => camper.id === id) as Camper;
         if (docUpdates.parentIds.every(parentId => existingCamper.parentIds.includes(parentId))) return;
         return updateUserDoc(id, {
-          parentIds: FieldValue.arrayUnion(...camperUpdates.parentIds),
+          parentIds: FieldValue.arrayUnion(...docUpdates.parentIds),
         }, transaction);
       }),
       existingParentUpdates.map((parentUpdates) => {

--- a/functions/src/features/userCsvProcessing.ts
+++ b/functions/src/features/userCsvProcessing.ts
@@ -49,7 +49,7 @@ export const processFamilyCsv = onCall(async (req) => {
       existingCamperUpdates.map((camperUpdates) => {
         const { id, ...docUpdates } = camperUpdates;
         const existingCamper = existingUsers.find(camper => camper.id === id) as Camper;
-        if (existingCamper.name.firstName === docUpdates.name.firstName && existingCamper.name.middleName === docUpdates.name.middleName && existingCamper.name.lastName === docUpdates.name.lastName && docUpdates.parentIds.every(parentId => existingCamper.parentIds.includes(parentId))) return;
+        if (docUpdates.parentIds.every(parentId => existingCamper.parentIds.includes(parentId))) return;
         return updateUserDoc(id, {
           parentIds: FieldValue.arrayUnion(...camperUpdates.parentIds),
         }, transaction);
@@ -57,7 +57,7 @@ export const processFamilyCsv = onCall(async (req) => {
       existingParentUpdates.map((parentUpdates) => {
         const { id, ...docUpdates } = parentUpdates;
         const existingParent = existingUsers.find(parent => parent.id === id) as Parent;
-        if (existingParent.name.firstName === docUpdates.name.firstName && existingParent.name.middleName === docUpdates.name.middleName && existingParent.name.lastName === docUpdates.name.lastName && docUpdates.camperIds.every(camperId => existingParent.camperIds.includes(camperId))) return;
+        if (docUpdates.camperIds.every(camperId => existingParent.camperIds.includes(camperId))) return;
         return updateUserDoc(id, {
           camperIds: FieldValue.arrayUnion(...docUpdates.camperIds),
         }, transaction);


### PR DESCRIPTION
- When parsing family user CSV files, the list of all IDs was extracted using `Object.keys` on an array, which always just returned array indices instead of user IDs, causing every user uploaded to be treated as a new user, leading to `already-exists` errors
  - Changed it to get the user IDs using a couple `.map` statements
- Removed old name checks for existing users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved family CSV processing so existing camper and parent records are matched more reliably during imports.
  * Reduced unnecessary duplicate linking when the same parent or camper IDs are already present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->