### PR TITLE
feat(activities): add ability to add activities to sections

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -20,7 +20,7 @@
     "google-auth-library": "^10.7.0",
     "googleapis": "^173.0.0",
     "moment": "^2.30.1",
-    "zod": "^3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.44.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "tailwind-preset-mantine": "^4.0.3",
         "tsc-alias": "^1.8.16",
         "uuid": "^11.1.0",
-        "zod": "^3.25.76",
+        "zod": "^4.4.3",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -562,7 +562,7 @@
         "google-auth-library": "^10.7.0",
         "googleapis": "^173.0.0",
         "moment": "^2.30.1",
-        "zod": "^3.25.76"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.44.1",
@@ -14142,7 +14142,9 @@
       "license": "MIT"
     },
     "node_modules/zod": {
-      "version": "3.25.76",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "tailwind-preset-mantine": "^4.0.3",
     "tsc-alias": "^1.8.16",
     "uuid": "^11.1.0",
-    "zod": "^3.25.76",
+    "zod": "^4.4.3",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/src/components/ActivityGrid.tsx
+++ b/src/components/ActivityGrid.tsx
@@ -60,8 +60,8 @@ export function ActivityGridContent(props: ActivityGridContentProps) {
   const attendeeGroups = useMemo(() => getAttendeeGroups(attendees), [attendees]);
 
   return (
-    <SimpleGrid className="grid-cols-[minmax(20px,60px)_20px_minmax(0px,3fr)_20px] gap-0 border border-neutral-5">
-      <Box className="col-start-1 col-end-5 bg-neutral-3 border border-neutral-5">
+    <SimpleGrid className="grid-cols-[minmax(20px,60px)_20px_20px_minmax(0px,3fr)_20px] gap-0 border border-neutral-5">
+      <Box className="col-start-1 col-end-6 bg-neutral-3 border border-neutral-5">
         Options
       </Box>
       {Object.keys(schedule.blocks)

--- a/src/components/ActivityGridRow.tsx
+++ b/src/components/ActivityGridRow.tsx
@@ -4,6 +4,7 @@ import { AttendeeGroups } from "@/features/scheduling/generation/schedulingUtils
 import { Text, ActionIcon, ScrollArea } from "@mantine/core";
 import ActivityGridCell from "@/components/ActivityGridCell";
 import { MdAdd, MdChevronLeft, MdChevronRight } from "react-icons/md";
+import openCreateActivityModal from "@/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal";
 
 interface ActivityGridRowProps {
   block: Block;
@@ -25,6 +26,7 @@ export default function ActivityGridRow(props: ActivityGridRowProps) {
         }}
         variant="subtle"
         size="xs"
+        onClick={() => openCreateActivityModal({ sessionId: section.sessionId, sectionId: section.id, blockId: id })}
       >
         <MdAdd size={40} />
       </ActionIcon>

--- a/src/components/ActivityGridRow.tsx
+++ b/src/components/ActivityGridRow.tsx
@@ -3,7 +3,7 @@ import { SchedulingSection } from "@/types/sessions/sessionTypes";
 import { AttendeeGroups } from "@/features/scheduling/generation/schedulingUtils";
 import { Text, ActionIcon, ScrollArea } from "@mantine/core";
 import ActivityGridCell from "@/components/ActivityGridCell";
-import { MdChevronLeft, MdChevronRight } from "react-icons/md";
+import { MdAdd, MdChevronLeft, MdChevronRight } from "react-icons/md";
 
 interface ActivityGridRowProps {
   block: Block;
@@ -19,6 +19,15 @@ export default function ActivityGridRow(props: ActivityGridRowProps) {
       <Text className="flex justify-center items-center w-full h-full p-0 border border-solid border-neutral-5 bg-neutral-2 text-sm font-semibold">
         Block {id}
       </Text>
+      <ActionIcon
+        classNames={{
+          root: "w-full h-full rounded-none border border-solid border-neutral-5",
+        }}
+        variant="subtle"
+        size="xs"
+      >
+        <MdAdd size={40} />
+      </ActionIcon>
       <ActionIcon
         classNames={{
           root: "w-full h-full rounded-none border border-solid border-neutral-5",

--- a/src/data/firestore/programAreas.ts
+++ b/src/data/firestore/programAreas.ts
@@ -13,8 +13,9 @@ import {
   DocumentSnapshot,
   WithFieldValue
 } from "firebase/firestore";
-import { setDoc, getDoc, updateDoc, deleteDoc, batchGetDocs } from "./firestoreClientOperations";
+import { setDoc, getDoc, updateDoc, deleteDoc, batchGetDocs, executeQuery, mapSnapshotsToPaginatedQueryResult } from "./firestoreClientOperations";
 import { RootLevelCollection } from "./types/collections";
+import { FirestoreQueryOptions, PaginatedQueryResponse } from "./types/queries";
 
 function fromFirestore(snapshot: DocumentSnapshot<ProgramAreaDoc, ProgramAreaDoc> | QueryDocumentSnapshot<ProgramAreaDoc, ProgramAreaDoc>): ProgramArea {
   if (!snapshot.exists()) { throw Error("Document not found"); }
@@ -32,6 +33,11 @@ export async function getProgramAreaDoc(id: string, transaction?: Transaction): 
 export async function batchGetProgramAreaDocs(ids: string[]): Promise<ProgramArea[]> {
   const snapshots = await batchGetDocs<ProgramAreaDoc>(collection(db, RootLevelCollection.PROGRAM_AREAS) as CollectionReference<ProgramAreaDoc, ProgramAreaDoc>, ids);
   return snapshots.map(fromFirestore);
+}
+
+export async function listProgramAreaDocs(firestoreQueryOptions: FirestoreQueryOptions<ProgramAreaDoc> = {}): Promise<PaginatedQueryResponse<ProgramArea, ProgramAreaDoc>> {
+  const snapshots = await executeQuery<ProgramAreaDoc>(collection(db, RootLevelCollection.PROGRAM_AREAS) as CollectionReference<ProgramAreaDoc, ProgramAreaDoc>, firestoreQueryOptions);
+  return mapSnapshotsToPaginatedQueryResult(snapshots, fromFirestore);
 }
 
 export async function createProgramAreaDoc(id: string, programArea: WithFieldValue<ProgramAreaDoc>, instance?: Transaction | WriteBatch): Promise<void> {

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -99,6 +99,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
     <div className="flex flex-col gap-sm">
       <form.Field
         name="name"
+        key="name"
         validators={{
           onBlur: ({ value }) => {
             const validationResult = (
@@ -128,6 +129,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
       </form.Field>
       <form.Field
         name="description"
+        key="description"
         validators={{
           onBlur: ({ value }) => {
             const validationResult = (
@@ -156,7 +158,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
       </form.Field>
       {sectionScheduleQuery.data.type === "BUNDLE" && (
         <>
-          <form.Field name="ageGroup">
+          <form.Field name="ageGroup" key="ageGroup">
             {(field) => (
               <Radio.Group
                 label="Age Group"
@@ -173,7 +175,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
               </Radio.Group>
             )}
           </form.Field>
-          <form.Field name="programAreaId">
+          <form.Field name="programAreaId" key="programAreaId">
             {(field) => (
               <Select
                 label="Program Area"

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -67,17 +67,18 @@ function CreateActivityModal(props: CreateActivityModalProps) {
   const createActivityMutation = useCreateActivity();
 
   const form = useForm({
-    defaultValues: sectionScheduleQuery.data.type === "BUNDLE"
-    ? {
-        name: "",
-        description: "",
-        ageGroup: "NAV" as AgeGroup,
-        programAreaId: null as string | null,
-      }
-    : {
-        name: "",
-        description: "",
-      },
+    defaultValues:
+      sectionScheduleQuery.data.type === "BUNDLE"
+        ? {
+            name: "",
+            description: "",
+            ageGroup: "NAV" as AgeGroup,
+            programAreaId: null as string | null,
+          }
+        : {
+            name: "",
+            description: "",
+          },
     validators: {
       onSubmit: CreateActivityFormDataSchema,
     },
@@ -175,7 +176,19 @@ function CreateActivityModal(props: CreateActivityModalProps) {
               </Radio.Group>
             )}
           </form.Field>
-          <form.Field name="programAreaId" key="programAreaId">
+          <form.Field
+            name="programAreaId"
+            key="programAreaId"
+            validators={{
+              onSubmit: ({ value }) => {
+                const validationResult = CreateBundleActivityFormDataSchema.shape.programAreaId.safeParse(value);
+                if (validationResult.success) return;
+                return validationResult.error.issues
+                  .map((issue) => issue.message)
+                  .join(", ");
+              }
+            }}
+          >
             {(field) => (
               <Select
                 label="Program Area"
@@ -186,6 +199,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
                 value={field.state.value}
                 onChange={(value) => field.handleChange(value)}
                 onBlur={field.handleBlur}
+                error={field.state.meta.errors.join(", ")}
                 required
               />
             )}

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -123,6 +123,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
             onChange={(e) => field.handleChange(e.target.value)}
             onBlur={field.handleBlur}
             error={field.state.meta.errors.join(", ")}
+            required
           />
         )}
       </form.Field>
@@ -149,6 +150,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
             onChange={(e) => field.handleChange(e.target.value)}
             onBlur={field.handleBlur}
             error={field.state.meta.errors.join(", ")}
+            required
           />
         )}
       </form.Field>
@@ -164,7 +166,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
             }
           }}>
             {(field) => (
-              <Radio.Group label="Age Group" onChange={(value: AgeGroup) => field.handleChange(value)} onBlur={field.handleBlur}>
+              <Radio.Group label="Age Group" onChange={(value: AgeGroup) => field.handleChange(value)} onBlur={field.handleBlur} required>
                 {AGE_GROUPS.map((ageGroup) => (
                   <Radio value={ageGroup} label={ageGroup} />
                 ))}
@@ -189,6 +191,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
                 }))}
                 onChange={(value) => field.handleChange(value ?? "")}
                 onBlur={field.handleBlur}
+                required
               />
             )}
           </form.Field>

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -160,21 +160,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
       </form.Field>
       {sectionScheduleQuery.data.type === "BUNDLE" && (
         <>
-          <form.Field
-            name="ageGroup"
-            validators={{
-              onChange: ({ value }) => {
-                const validationResult =
-                  CreateBundleActivityFormDataSchema.shape.ageGroup.safeParse(
-                    value,
-                  );
-                if (validationResult.success) return;
-                return validationResult.error.issues
-                  .map((issue) => issue.message)
-                  .join(", ");
-              },
-            }}
-          >
+          <form.Field name="ageGroup">
             {(field) => (
               <Radio.Group
                 label="Age Group"
@@ -191,21 +177,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
               </Radio.Group>
             )}
           </form.Field>
-          <form.Field
-            name="programAreaId"
-            validators={{
-              onChange: ({ value }) => {
-                const validationResult =
-                  CreateBundleActivityFormDataSchema.shape.programAreaId.safeParse(
-                    value,
-                  );
-                if (validationResult.success) return;
-                return validationResult.error.issues
-                  .map((issue) => issue.message)
-                  .join(", ");
-              },
-            }}
-          >
+          <form.Field name="programAreaId">
             {(field) => (
               <Select
                 label="Program Area"

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -8,7 +8,7 @@ import {
   AgeGroup,
   SchedulingSectionType,
 } from "@/types/sessions/sessionTypes";
-import { Radio, Select, Textarea, TextInput } from "@mantine/core";
+import { Button, Radio, Select, Textarea, TextInput } from "@mantine/core";
 import { openModal } from "@mantine/modals";
 import {
   useSuspenseInfiniteQuery,
@@ -52,22 +52,6 @@ const CreateActivityFormDataSchema = z.union([
 ]);
 type CreateActivityFormData = z.infer<typeof CreateActivityFormDataSchema>;
 
-function getCreateActivityFormDefaultValues(
-  type: SchedulingSectionType,
-): CreateActivityFormData {
-  return type === "BUNDLE"
-    ? ({
-        name: "",
-        description: "",
-        ageGroup: "NAV",
-        programAreaId: "",
-      } satisfies CreateBundleActivityFormData)
-    : ({
-        name: "",
-        description: "",
-      } satisfies CreateJamboreeActivityFormData);
-}
-
 function CreateActivityModal(props: CreateActivityModalProps) {
   const { sessionId, sectionId, blockId } = props;
 
@@ -76,25 +60,37 @@ function CreateActivityModal(props: CreateActivityModalProps) {
   );
   const programAreasQuery = useSuspenseInfiniteQuery(
     getUseProgramAreaListOptions({
-      where: [{ fieldPath: "isDeleted", operation: "==", value: false }]
+      where: [{ fieldPath: "isDeleted", operation: "==", value: false }],
     }),
   );
 
   const createActivityMutation = useCreateActivity();
 
   const form = useForm({
-    defaultValues: getCreateActivityFormDefaultValues(
-      sectionScheduleQuery.data.type,
-    ),
+    defaultValues: sectionScheduleQuery.data.type === "BUNDLE"
+    ? {
+        name: "",
+        description: "",
+        ageGroup: "NAV" as AgeGroup,
+        programAreaId: undefined as string | undefined,
+      }
+    : {
+        name: "",
+        description: "",
+      },
     validators: {
       onSubmit: CreateActivityFormDataSchema,
     },
     onSubmit: async ({ value }) => {
+      const validationResult = CreateActivityFormDataSchema.safeParse(value);
+      if (!validationResult.success) {
+        return;
+      }
       createActivityMutation.mutate({
         sessionId,
         sectionId,
         blockId,
-        ...value,
+        ...validationResult.data,
       });
     },
   });
@@ -186,7 +182,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
                   label: `${programArea.id}: ${programArea.name}`,
                 }))}
                 value={field.state.value}
-                onChange={(value) => field.handleChange(value ?? "")}
+                onChange={(value) => field.handleChange(value ?? undefined)}
                 onBlur={field.handleBlur}
                 required
               />

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -164,7 +164,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
               >
                 <div className="flex flex-col gap-xs">
                   {AGE_GROUPS.map((ageGroup) => (
-                    <Radio value={ageGroup} label={ageGroup} />
+                    <Radio key={ageGroup} value={ageGroup} label={ageGroup} />
                   ))}
                 </div>
               </Radio.Group>

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -5,6 +5,7 @@ import useCreateActivity, {
 import { sectionScheduleQueryOptions } from "@/hooks/schedules/useSectionSchedule";
 import {
   AGE_GROUPS,
+  AgeGroup,
   SchedulingSectionType,
 } from "@/types/sessions/sessionTypes";
 import { Radio, Select, Textarea, TextInput } from "@mantine/core";
@@ -51,7 +52,9 @@ const CreateActivityFormDataSchema = z.union([
 ]);
 type CreateActivityFormData = z.infer<typeof CreateActivityFormDataSchema>;
 
-function getCreateActivityFormDefaultValues(type: SchedulingSectionType): CreateActivityFormData {
+function getCreateActivityFormDefaultValues(
+  type: SchedulingSectionType,
+): CreateActivityFormData {
   return type === "BUNDLE"
     ? ({
         name: "",
@@ -96,22 +99,99 @@ function CreateActivityModal(props: CreateActivityModalProps) {
 
   return (
     <div>
-      <TextInput label="Activity Name" />
-      <Textarea label="Activity Description" />
+      <form.Field
+        name="name"
+        validators={{
+          onBlur: ({ value }) => {
+            const validationResult = (
+              sectionScheduleQuery.data.type === "BUNDLE"
+                ? CreateBundleActivityFormDataSchema
+                : CreateJamboreeActivityFormDataSchema
+            ).shape.name.safeParse(value);
+            console.log(validationResult);
+            if (validationResult.success) return;
+            return validationResult.error.issues
+              .map((issue) => issue.message)
+              .join(", ");
+          },
+        }}
+      >
+        {(field) => (
+          <TextInput
+            name={field.name}
+            label="Name"
+            onChange={(e) => field.handleChange(e.target.value)}
+            onBlur={field.handleBlur}
+            error={field.state.meta.errors.join(", ")}
+          />
+        )}
+      </form.Field>
+      <form.Field
+        name="description"
+        validators={{
+          onBlur: ({ value }) => {
+            const validationResult = (
+              sectionScheduleQuery.data.type === "BUNDLE"
+                ? CreateBundleActivityFormDataSchema
+                : CreateJamboreeActivityFormDataSchema
+            ).shape.description.safeParse(value);
+            if (validationResult.success) return;
+            return validationResult.error.issues
+              .map((issue) => issue.message)
+              .join(", ");
+          },
+        }}
+      >
+        {(field) => (
+          <Textarea
+            name={field.name}
+            label="Description"
+            onChange={(e) => field.handleChange(e.target.value)}
+            onBlur={field.handleBlur}
+            error={field.state.meta.errors.join(", ")}
+          />
+        )}
+      </form.Field>
       {sectionScheduleQuery.data.type === "BUNDLE" && (
         <>
-          <Radio.Group label="Age Group">
-            {AGE_GROUPS.map((ageGroup) => (
-              <Radio value={ageGroup} label={ageGroup} />
-            ))}
-          </Radio.Group>
-          <Select
-            label="Program Area"
-            data={programAreasQuery.data.map((programArea) => ({
-              value: programArea.id,
-              label: programArea.name,
-            }))}
-          ></Select>
+          <form.Field name="ageGroup" validators={{
+            onChange: ({ value }) => {
+              const validationResult = CreateBundleActivityFormDataSchema.shape.ageGroup.safeParse(value);
+              if (validationResult.success) return;
+              return validationResult.error.issues
+                .map((issue) => issue.message)
+                .join(", ");
+            }
+          }}>
+            {(field) => (
+              <Radio.Group label="Age Group" onChange={(value: AgeGroup) => field.handleChange(value)} onBlur={field.handleBlur}>
+                {AGE_GROUPS.map((ageGroup) => (
+                  <Radio value={ageGroup} label={ageGroup} />
+                ))}
+              </Radio.Group>
+            )}
+          </form.Field>
+          <form.Field name="programAreaId" validators={{
+            onChange: ({ value }) => {
+              const validationResult = CreateBundleActivityFormDataSchema.shape.programAreaId.safeParse(value);
+              if (validationResult.success) return;
+              return validationResult.error.issues
+                .map((issue) => issue.message)
+                .join(", ");
+            }
+          }}>
+            {(field) => (
+              <Select
+                label="Program Area"
+                data={programAreasQuery.data.map((programArea) => ({
+                  value: programArea.id,
+                  label: programArea.name,
+                }))}
+                onChange={(value) => field.handleChange(value ?? "")}
+                onBlur={field.handleBlur}
+              />
+            )}
+          </form.Field>
         </>
       )}
     </div>

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -183,7 +183,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
                 label="Program Area"
                 data={programAreasQuery.data.map((programArea) => ({
                   value: programArea.id,
-                  label: programArea.name,
+                  label: `${programArea.id}: ${programArea.name}`,
                 }))}
                 value={field.state.value}
                 onChange={(value) => field.handleChange(value ?? "")}

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -108,7 +108,6 @@ function CreateActivityModal(props: CreateActivityModalProps) {
                 ? CreateBundleActivityFormDataSchema
                 : CreateJamboreeActivityFormDataSchema
             ).shape.name.safeParse(value);
-            console.log(validationResult);
             if (validationResult.success) return;
             return validationResult.error.issues
               .map((issue) => issue.message)

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -98,7 +98,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
   });
 
   return (
-    <div>
+    <div className="flex flex-col gap-sm">
       <form.Field
         name="name"
         validators={{
@@ -181,9 +181,11 @@ function CreateActivityModal(props: CreateActivityModalProps) {
                 onBlur={field.handleBlur}
                 required
               >
-                {AGE_GROUPS.map((ageGroup) => (
-                  <Radio value={ageGroup} label={ageGroup} />
-                ))}
+                <div className="flex flex-col gap-xs">
+                  {AGE_GROUPS.map((ageGroup) => (
+                    <Radio value={ageGroup} label={ageGroup} />
+                  ))}
+                </div>
               </Radio.Group>
             )}
           </form.Field>

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -9,7 +9,7 @@ import {
   SchedulingSectionType,
 } from "@/types/sessions/sessionTypes";
 import { Button, Radio, Select, Textarea, TextInput } from "@mantine/core";
-import { openModal } from "@mantine/modals";
+import { modals, openModal } from "@mantine/modals";
 import {
   useSuspenseInfiniteQuery,
   useSuspenseQuery,
@@ -87,12 +87,17 @@ function CreateActivityModal(props: CreateActivityModalProps) {
       if (!validationResult.success) {
         return;
       }
-      createActivityMutation.mutate({
-        sessionId,
-        sectionId,
-        blockId,
-        ...validationResult.data,
-      });
+      await createActivityMutation.mutateAsync(
+        {
+          sessionId,
+          sectionId,
+          blockId,
+          ...validationResult.data,
+        },
+        {
+          onSuccess: () => modals.close(createActivityModalId(props)),
+        },
+      );
     },
   });
 
@@ -180,12 +185,15 @@ function CreateActivityModal(props: CreateActivityModalProps) {
             key="programAreaId"
             validators={{
               onSubmit: ({ value }) => {
-                const validationResult = CreateBundleActivityFormDataSchema.shape.programAreaId.safeParse(value);
+                const validationResult =
+                  CreateBundleActivityFormDataSchema.shape.programAreaId.safeParse(
+                    value,
+                  );
                 if (validationResult.success) return;
                 return validationResult.error.issues
                   .map((issue) => issue.message)
                   .join(", ");
-              }
+              },
             }}
           >
             {(field) => (
@@ -205,11 +213,19 @@ function CreateActivityModal(props: CreateActivityModalProps) {
           </form.Field>
         </>
       )}
-      <Button color="green" onClick={form.handleSubmit}>
+      <Button
+        color="green"
+        onClick={form.handleSubmit}
+        loading={form.state.isSubmitting}
+      >
         Submit
       </Button>
     </div>
   );
+}
+
+function createActivityModalId(props: CreateActivityModalProps) {
+  return `create-activity-modal-${props.sessionId}-${props.sectionId}-${props.blockId}`;
 }
 
 export default function openCreateActivityModal(
@@ -217,6 +233,7 @@ export default function openCreateActivityModal(
 ) {
   openModal({
     title: "Create Activity",
+    modalId: createActivityModalId(props),
     children: (
       <ErrorBoundary
         fallbackRender={({ error }) => (

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -1,0 +1,31 @@
+import useCreateActivity from "@/features/sessions/sections/useCreateActivity";
+import { sectionScheduleQueryOptions } from "@/hooks/schedules/useSectionSchedule";
+import { openModal } from "@mantine/modals";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+interface CreateActivityModalProps {
+  sessionId: string;
+  sectionId: string;
+  blockId: string;
+}
+
+function CreateActivityModal(props: CreateActivityModalProps) {
+  const { sessionId, sectionId, blockId } = props;
+
+  const sectionScheduleQuery = useSuspenseQuery(
+    sectionScheduleQueryOptions(sessionId, sectionId),
+  );
+
+  const createActivityMutation = useCreateActivity();
+
+  return <div></div>;
+}
+
+export default function openCreateActivityModal(
+  props: CreateActivityModalProps,
+) {
+  openModal({
+    title: "Create Activity",
+    children: <CreateActivityModal {...props} />,
+  });
+}

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -1,12 +1,25 @@
-import useCreateActivity, { CreateBundleActivityRequestSchema, CreateJamboreeActivityRequestSchema } from "@/features/sessions/sections/useCreateActivity";
+import useCreateActivity, {
+  CreateBundleActivityRequestSchema,
+  CreateJamboreeActivityRequestSchema,
+} from "@/features/sessions/sections/useCreateActivity";
 import { sectionScheduleQueryOptions } from "@/hooks/schedules/useSectionSchedule";
-import { AGE_GROUPS, SchedulingSectionType } from "@/types/sessions/sessionTypes";
+import {
+  AGE_GROUPS,
+  SchedulingSectionType,
+} from "@/types/sessions/sessionTypes";
 import { Radio, Select, Textarea, TextInput } from "@mantine/core";
 import { openModal } from "@mantine/modals";
-import { useSuspenseInfiniteQuery, useSuspenseQuery } from "@tanstack/react-query";
+import {
+  useSuspenseInfiniteQuery,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import { useForm } from "@tanstack/react-form";
 import z from "zod";
 import { getUseProgramAreaListOptions } from "@/hooks/programAreas/useProgramAreaList";
+import { ErrorBoundary } from "react-error-boundary";
+import { Suspense } from "react";
+import LoadingPage from "@/app/loading";
+import ErrorPage from "@/app/error";
 
 interface CreateActivityModalProps {
   sessionId: string;
@@ -73,6 +86,18 @@ export default function openCreateActivityModal(
 ) {
   openModal({
     title: "Create Activity",
-    children: <CreateActivityModal {...props} />,
+    children: (
+      <ErrorBoundary
+        fallbackRender={({ error }) => (
+          <ErrorPage
+            error={error instanceof Error ? error : Error("Unknown Error")}
+          />
+        )}
+      >
+        <Suspense fallback={<LoadingPage />}>
+          <CreateActivityModal {...props} />
+        </Suspense>
+      </ErrorBoundary>
+    ),
   });
 }

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -6,7 +6,6 @@ import { sectionScheduleQueryOptions } from "@/hooks/schedules/useSectionSchedul
 import {
   AGE_GROUPS,
   AgeGroup,
-  SchedulingSectionType,
 } from "@/types/sessions/sessionTypes";
 import { Button, Radio, Select, Textarea, TextInput } from "@mantine/core";
 import { modals, openModal } from "@mantine/modals";
@@ -34,23 +33,18 @@ const CreateBundleActivityFormDataSchema =
     sectionId: true,
     blockId: true,
   });
-type CreateBundleActivityFormData = z.infer<
-  typeof CreateBundleActivityFormDataSchema
->;
+
 const CreateJamboreeActivityFormDataSchema =
   CreateJamboreeActivityRequestSchema.omit({
     sessionId: true,
     sectionId: true,
     blockId: true,
   });
-type CreateJamboreeActivityFormData = z.infer<
-  typeof CreateJamboreeActivityFormDataSchema
->;
+
 const CreateActivityFormDataSchema = z.union([
   CreateJamboreeActivityFormDataSchema,
   CreateBundleActivityFormDataSchema,
 ]);
-type CreateActivityFormData = z.infer<typeof CreateActivityFormDataSchema>;
 
 function CreateActivityModal(props: CreateActivityModalProps) {
   const { sessionId, sectionId, blockId } = props;
@@ -65,6 +59,10 @@ function CreateActivityModal(props: CreateActivityModalProps) {
   );
 
   const createActivityMutation = useCreateActivity();
+
+  const validationSchema = sectionScheduleQuery.data.type === "BUNDLE"
+    ? CreateBundleActivityRequestSchema
+    : CreateJamboreeActivityRequestSchema;
 
   const form = useForm({
     defaultValues:
@@ -108,11 +106,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
         key="name"
         validators={{
           onBlur: ({ value }) => {
-            const validationResult = (
-              sectionScheduleQuery.data.type === "BUNDLE"
-                ? CreateBundleActivityFormDataSchema
-                : CreateJamboreeActivityFormDataSchema
-            ).shape.name.safeParse(value);
+            const validationResult = validationSchema.shape.name.safeParse(value);
             if (validationResult.success) return;
             return validationResult.error.issues
               .map((issue) => issue.message)
@@ -137,11 +131,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
         key="description"
         validators={{
           onBlur: ({ value }) => {
-            const validationResult = (
-              sectionScheduleQuery.data.type === "BUNDLE"
-                ? CreateBundleActivityFormDataSchema
-                : CreateJamboreeActivityFormDataSchema
-            ).shape.description.safeParse(value);
+            const validationResult = validationSchema.shape.description.safeParse(value);
             if (validationResult.success) return;
             return validationResult.error.issues
               .map((issue) => issue.message)

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -1,5 +1,7 @@
 import useCreateActivity from "@/features/sessions/sections/useCreateActivity";
 import { sectionScheduleQueryOptions } from "@/hooks/schedules/useSectionSchedule";
+import { AGE_GROUPS } from "@/types/sessions/sessionTypes";
+import { Radio, Textarea, TextInput } from "@mantine/core";
 import { openModal } from "@mantine/modals";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
@@ -18,7 +20,19 @@ function CreateActivityModal(props: CreateActivityModalProps) {
 
   const createActivityMutation = useCreateActivity();
 
-  return <div></div>;
+  return (
+    <div>
+      <TextInput label="Activity Name" />
+      <Textarea label="Activity Description" />
+      {sectionScheduleQuery.data.type === "BUNDLE" && (
+        <Radio.Group label="Age Group">
+          {AGE_GROUPS.map((ageGroup) => (
+            <Radio value={ageGroup} label={ageGroup} />
+          ))}
+        </Radio.Group>
+      )}
+    </div>
+  );
 }
 
 export default function openCreateActivityModal(

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -75,7 +75,9 @@ function CreateActivityModal(props: CreateActivityModalProps) {
     sectionScheduleQueryOptions(sessionId, sectionId),
   );
   const programAreasQuery = useSuspenseInfiniteQuery(
-    getUseProgramAreaListOptions(),
+    getUseProgramAreaListOptions({
+      where: [{ fieldPath: "isDeleted", operation: "==", value: false }]
+    }),
   );
 
   const createActivityMutation = useCreateActivity();

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -120,6 +120,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
           <TextInput
             name={field.name}
             label="Name"
+            value={field.state.value}
             onChange={(e) => field.handleChange(e.target.value)}
             onBlur={field.handleBlur}
             error={field.state.meta.errors.join(", ")}
@@ -147,6 +148,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
           <Textarea
             name={field.name}
             label="Description"
+            value={field.state.value}
             onChange={(e) => field.handleChange(e.target.value)}
             onBlur={field.handleBlur}
             error={field.state.meta.errors.join(", ")}
@@ -156,32 +158,50 @@ function CreateActivityModal(props: CreateActivityModalProps) {
       </form.Field>
       {sectionScheduleQuery.data.type === "BUNDLE" && (
         <>
-          <form.Field name="ageGroup" validators={{
-            onChange: ({ value }) => {
-              const validationResult = CreateBundleActivityFormDataSchema.shape.ageGroup.safeParse(value);
-              if (validationResult.success) return;
-              return validationResult.error.issues
-                .map((issue) => issue.message)
-                .join(", ");
-            }
-          }}>
+          <form.Field
+            name="ageGroup"
+            validators={{
+              onChange: ({ value }) => {
+                const validationResult =
+                  CreateBundleActivityFormDataSchema.shape.ageGroup.safeParse(
+                    value,
+                  );
+                if (validationResult.success) return;
+                return validationResult.error.issues
+                  .map((issue) => issue.message)
+                  .join(", ");
+              },
+            }}
+          >
             {(field) => (
-              <Radio.Group label="Age Group" onChange={(value: AgeGroup) => field.handleChange(value)} onBlur={field.handleBlur} required>
+              <Radio.Group
+                label="Age Group"
+                value={field.state.value}
+                onChange={(value: AgeGroup) => field.handleChange(value)}
+                onBlur={field.handleBlur}
+                required
+              >
                 {AGE_GROUPS.map((ageGroup) => (
                   <Radio value={ageGroup} label={ageGroup} />
                 ))}
               </Radio.Group>
             )}
           </form.Field>
-          <form.Field name="programAreaId" validators={{
-            onChange: ({ value }) => {
-              const validationResult = CreateBundleActivityFormDataSchema.shape.programAreaId.safeParse(value);
-              if (validationResult.success) return;
-              return validationResult.error.issues
-                .map((issue) => issue.message)
-                .join(", ");
-            }
-          }}>
+          <form.Field
+            name="programAreaId"
+            validators={{
+              onChange: ({ value }) => {
+                const validationResult =
+                  CreateBundleActivityFormDataSchema.shape.programAreaId.safeParse(
+                    value,
+                  );
+                if (validationResult.success) return;
+                return validationResult.error.issues
+                  .map((issue) => issue.message)
+                  .join(", ");
+              },
+            }}
+          >
             {(field) => (
               <Select
                 label="Program Area"
@@ -189,6 +209,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
                   value: programArea.id,
                   label: programArea.name,
                 }))}
+                value={field.state.value}
                 onChange={(value) => field.handleChange(value ?? "")}
                 onBlur={field.handleBlur}
                 required

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -44,7 +44,10 @@ function CreateActivityModal(props: CreateActivityModalProps) {
   const createActivityMutation = useCreateActivity();
 
   const form = useForm({
-    defaultValues: getCreateActivityFormDefaultValues(sectionScheduleQuery.data.type)
+    defaultValues: getCreateActivityFormDefaultValues(sectionScheduleQuery.data.type),
+    onSubmit: async ({ value }) => {
+      createActivityMutation.mutate({ sessionId, sectionId, blockId, ...value });
+    }
   })
 
   return (

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -58,7 +58,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
               <Radio value={ageGroup} label={ageGroup} />
             ))}
           </Radio.Group>
-          <Select label="Program Area" data={programAreasQuery.data.pages.flatMap(page => page.docs).map(programArea => ({ value: programArea.id, label: programArea.name }))}></Select>
+          <Select label="Program Area" data={programAreasQuery.data.map(programArea => ({ value: programArea.id, label: programArea.name }))}></Select>
         </>
       )}
     </div>

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -27,23 +27,42 @@ interface CreateActivityModalProps {
   blockId: string;
 }
 
-const CreateBundleActivityFormDataSchema = CreateBundleActivityRequestSchema.omit({ sessionId: true, sectionId: true, blockId: true });
-type CreateBundleActivityFormData = z.infer<typeof CreateBundleActivityFormDataSchema>;
-const CreateJamboreeActivityFormDataSchema = CreateJamboreeActivityRequestSchema.omit({ sessionId: true, sectionId: true, blockId: true });
-type CreateJamboreeActivityFormData = z.infer<typeof CreateJamboreeActivityFormDataSchema>;
-const CreateActivityFormDataSchema = z.union([CreateJamboreeActivityFormDataSchema, CreateBundleActivityFormDataSchema]);
+const CreateBundleActivityFormDataSchema =
+  CreateBundleActivityRequestSchema.omit({
+    sessionId: true,
+    sectionId: true,
+    blockId: true,
+  });
+type CreateBundleActivityFormData = z.infer<
+  typeof CreateBundleActivityFormDataSchema
+>;
+const CreateJamboreeActivityFormDataSchema =
+  CreateJamboreeActivityRequestSchema.omit({
+    sessionId: true,
+    sectionId: true,
+    blockId: true,
+  });
+type CreateJamboreeActivityFormData = z.infer<
+  typeof CreateJamboreeActivityFormDataSchema
+>;
+const CreateActivityFormDataSchema = z.union([
+  CreateJamboreeActivityFormDataSchema,
+  CreateBundleActivityFormDataSchema,
+]);
 type CreateActivityFormData = z.infer<typeof CreateActivityFormDataSchema>;
 
-function getCreateActivityFormDefaultValues(type: SchedulingSectionType) {
-  return type === "BUNDLE" ? {
-    name: "",
-    description: "",
-    ageGroup: "NAV",
-    programAreaId: ""
-  } satisfies CreateBundleActivityFormData : {
-    name: "",
-    description: ""
-  } satisfies CreateJamboreeActivityFormData
+function getCreateActivityFormDefaultValues(type: SchedulingSectionType): CreateActivityFormData {
+  return type === "BUNDLE"
+    ? ({
+        name: "",
+        description: "",
+        ageGroup: "NAV",
+        programAreaId: "",
+      } satisfies CreateBundleActivityFormData)
+    : ({
+        name: "",
+        description: "",
+      } satisfies CreateJamboreeActivityFormData);
 }
 
 function CreateActivityModal(props: CreateActivityModalProps) {
@@ -52,16 +71,28 @@ function CreateActivityModal(props: CreateActivityModalProps) {
   const sectionScheduleQuery = useSuspenseQuery(
     sectionScheduleQueryOptions(sessionId, sectionId),
   );
-  const programAreasQuery = useSuspenseInfiniteQuery(getUseProgramAreaListOptions());
+  const programAreasQuery = useSuspenseInfiniteQuery(
+    getUseProgramAreaListOptions(),
+  );
 
   const createActivityMutation = useCreateActivity();
 
   const form = useForm({
-    defaultValues: getCreateActivityFormDefaultValues(sectionScheduleQuery.data.type),
+    defaultValues: getCreateActivityFormDefaultValues(
+      sectionScheduleQuery.data.type,
+    ),
+    validators: {
+      onSubmit: CreateActivityFormDataSchema,
+    },
     onSubmit: async ({ value }) => {
-      createActivityMutation.mutate({ sessionId, sectionId, blockId, ...value });
-    }
-  })
+      createActivityMutation.mutate({
+        sessionId,
+        sectionId,
+        blockId,
+        ...value,
+      });
+    },
+  });
 
   return (
     <div>
@@ -74,7 +105,13 @@ function CreateActivityModal(props: CreateActivityModalProps) {
               <Radio value={ageGroup} label={ageGroup} />
             ))}
           </Radio.Group>
-          <Select label="Program Area" data={programAreasQuery.data.map(programArea => ({ value: programArea.id, label: programArea.name }))}></Select>
+          <Select
+            label="Program Area"
+            data={programAreasQuery.data.map((programArea) => ({
+              value: programArea.id,
+              label: programArea.name,
+            }))}
+          ></Select>
         </>
       )}
     </div>

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -72,7 +72,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
         name: "",
         description: "",
         ageGroup: "NAV" as AgeGroup,
-        programAreaId: undefined as string | undefined,
+        programAreaId: null as string | null,
       }
     : {
         name: "",
@@ -184,7 +184,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
                   label: `${programArea.id}: ${programArea.name}`,
                 }))}
                 value={field.state.value}
-                onChange={(value) => field.handleChange(value ?? undefined)}
+                onChange={(value) => field.handleChange(value)}
                 onBlur={field.handleBlur}
                 required
               />

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -1,11 +1,12 @@
 import useCreateActivity, { CreateBundleActivityRequestSchema, CreateJamboreeActivityRequestSchema } from "@/features/sessions/sections/useCreateActivity";
 import { sectionScheduleQueryOptions } from "@/hooks/schedules/useSectionSchedule";
 import { AGE_GROUPS, SchedulingSectionType } from "@/types/sessions/sessionTypes";
-import { Radio, Textarea, TextInput } from "@mantine/core";
+import { Radio, Select, Textarea, TextInput } from "@mantine/core";
 import { openModal } from "@mantine/modals";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseInfiniteQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useForm } from "@tanstack/react-form";
 import z from "zod";
+import { getUseProgramAreaListOptions } from "@/hooks/programAreas/useProgramAreaList";
 
 interface CreateActivityModalProps {
   sessionId: string;
@@ -38,6 +39,7 @@ function CreateActivityModal(props: CreateActivityModalProps) {
   const sectionScheduleQuery = useSuspenseQuery(
     sectionScheduleQueryOptions(sessionId, sectionId),
   );
+  const programAreasQuery = useSuspenseInfiniteQuery(getUseProgramAreaListOptions());
 
   const createActivityMutation = useCreateActivity();
 
@@ -50,11 +52,14 @@ function CreateActivityModal(props: CreateActivityModalProps) {
       <TextInput label="Activity Name" />
       <Textarea label="Activity Description" />
       {sectionScheduleQuery.data.type === "BUNDLE" && (
-        <Radio.Group label="Age Group">
-          {AGE_GROUPS.map((ageGroup) => (
-            <Radio value={ageGroup} label={ageGroup} />
-          ))}
-        </Radio.Group>
+        <>
+          <Radio.Group label="Age Group">
+            {AGE_GROUPS.map((ageGroup) => (
+              <Radio value={ageGroup} label={ageGroup} />
+            ))}
+          </Radio.Group>
+          <Select label="Program Area" data={programAreasQuery.data.pages.flatMap(page => page.docs).map(programArea => ({ value: programArea.id, label: programArea.name }))}></Select>
+        </>
       )}
     </div>
   );

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -194,6 +194,9 @@ function CreateActivityModal(props: CreateActivityModalProps) {
           </form.Field>
         </>
       )}
+      <Button color="green" onClick={form.handleSubmit}>
+        Submit
+      </Button>
     </div>
   );
 }

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -1,14 +1,35 @@
-import useCreateActivity from "@/features/sessions/sections/useCreateActivity";
+import useCreateActivity, { CreateBundleActivityRequestSchema, CreateJamboreeActivityRequestSchema } from "@/features/sessions/sections/useCreateActivity";
 import { sectionScheduleQueryOptions } from "@/hooks/schedules/useSectionSchedule";
-import { AGE_GROUPS } from "@/types/sessions/sessionTypes";
+import { AGE_GROUPS, SchedulingSectionType } from "@/types/sessions/sessionTypes";
 import { Radio, Textarea, TextInput } from "@mantine/core";
 import { openModal } from "@mantine/modals";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { useForm } from "@tanstack/react-form";
+import z from "zod";
 
 interface CreateActivityModalProps {
   sessionId: string;
   sectionId: string;
   blockId: string;
+}
+
+const CreateBundleActivityFormDataSchema = CreateBundleActivityRequestSchema.omit({ sessionId: true, sectionId: true, blockId: true });
+type CreateBundleActivityFormData = z.infer<typeof CreateBundleActivityFormDataSchema>;
+const CreateJamboreeActivityFormDataSchema = CreateJamboreeActivityRequestSchema.omit({ sessionId: true, sectionId: true, blockId: true });
+type CreateJamboreeActivityFormData = z.infer<typeof CreateJamboreeActivityFormDataSchema>;
+const CreateActivityFormDataSchema = z.union([CreateJamboreeActivityFormDataSchema, CreateBundleActivityFormDataSchema]);
+type CreateActivityFormData = z.infer<typeof CreateActivityFormDataSchema>;
+
+function getCreateActivityFormDefaultValues(type: SchedulingSectionType) {
+  return type === "BUNDLE" ? {
+    name: "",
+    description: "",
+    ageGroup: "NAV",
+    programAreaId: ""
+  } satisfies CreateBundleActivityFormData : {
+    name: "",
+    description: ""
+  } satisfies CreateJamboreeActivityFormData
 }
 
 function CreateActivityModal(props: CreateActivityModalProps) {
@@ -19,6 +40,10 @@ function CreateActivityModal(props: CreateActivityModalProps) {
   );
 
   const createActivityMutation = useCreateActivity();
+
+  const form = useForm({
+    defaultValues: getCreateActivityFormDefaultValues(sectionScheduleQuery.data.type)
+  })
 
   return (
     <div>

--- a/src/features/scheduling/generation/hooks/useGenerateSectionSchedule..ts
+++ b/src/features/scheduling/generation/hooks/useGenerateSectionSchedule..ts
@@ -7,7 +7,7 @@ import { generateBunkJamboreeSchedule } from "../generateBunkJamboreeSchedule";
 import { generateNonBunkJamboreeSchedule } from "../generateNonBunkJamboreeSchedule";
 import { getUseAttendeeListOptions } from "@/hooks/attendees/useAttendeeList";
 import { getUseActivityPreferencesOptions } from "@/hooks/activityPreferences/useActivityPreferences";
-import { getUseSectionScheduleOptions } from "@/hooks/schedules/useSectionSchedule";
+import { sectionScheduleQueryOptions } from "@/hooks/schedules/useSectionSchedule";
 import { getUseDaysOffScheduleOptions } from "@/hooks/daysOffSchedules/useDaysOffSchedule";
 import { Section } from "@/types/sessions/sessionTypes";
 import { getUseSectionListOptions } from "@/hooks/sections/useSectionList";
@@ -37,7 +37,7 @@ async function generateSectionSchedule(req: GenerateSectionScheduleRequest, clie
       return generateBundleSchedule({
         attendees: (await client.ensureInfiniteQueryData(getUseAttendeeListOptions(sessionId))).pages.flatMap(page => page.docs),
         camperActivityPreferences: await client.ensureQueryData(getUseActivityPreferencesOptions(req)),
-        currentSchedule: await client.ensureQueryData(getUseSectionScheduleOptions(sessionId, sectionId)) as BundleSectionSchedule,
+        currentSchedule: await client.ensureQueryData(sectionScheduleQueryOptions(sessionId, sectionId)) as BundleSectionSchedule,
         daysOffSchedule: await client.ensureQueryData(getUseDaysOffScheduleOptions(sessionId)),
         section,
         isFirstBundleOfSession
@@ -47,12 +47,12 @@ async function generateSectionSchedule(req: GenerateSectionScheduleRequest, clie
         attendees: (await client.ensureInfiniteQueryData(getUseAttendeeListOptions(sessionId))).pages.flatMap(page => page.docs),
         bunkActivityPreferences: await client.ensureQueryData(getUseActivityPreferencesOptions(req)),
         bunks: (await client.ensureInfiniteQueryData(getUseBunkListOptions(sessionId))).pages.flatMap(page => page.docs),
-        currentSchedule: await client.ensureQueryData(getUseSectionScheduleOptions(sessionId, sectionId)) as BunkJamboreeSectionSchedule
+        currentSchedule: await client.ensureQueryData(sectionScheduleQueryOptions(sessionId, sectionId)) as BunkJamboreeSectionSchedule
       });
     case "NON-BUNK-JAMBO":
       return generateNonBunkJamboreeSchedule({
         attendees: (await client.ensureInfiniteQueryData(getUseAttendeeListOptions(sessionId))).pages.flatMap(page => page.docs),
-        currentSchedule: await client.ensureQueryData(getUseSectionScheduleOptions(sessionId, sectionId)) as NonBunkJamboreeSectionSchedule,
+        currentSchedule: await client.ensureQueryData(sectionScheduleQueryOptions(sessionId, sectionId)) as NonBunkJamboreeSectionSchedule,
         sectionActivityPreferences: await client.ensureQueryData(getUseActivityPreferencesOptions(req)),
       });
   }

--- a/src/features/sessions/sections/useCreateActivity.ts
+++ b/src/features/sessions/sections/useCreateActivity.ts
@@ -13,7 +13,7 @@ export const CreateJamboreeActivityRequestSchema = z.strictObject({
   sectionId: z.uuid(),
   blockId: z.string().min(1),
   name: z.string().min(1, "Name is required").max(20, "Name must be 20 characters or less"),
-  description: z.string().min(1).max(200, "Description must be 200 characters or less"),
+  description: z.string().min(1, "Description is required").max(200, "Description must be 200 characters or less"),
   programAreaId: z.never().optional(),
   ageGroup: z.never().optional(),
 });
@@ -24,7 +24,7 @@ export const CreateBundleActivityRequestSchema = z.strictObject({
   sectionId: z.uuid(),
   blockId: z.string().min(1),
   name: z.string().min(1, "Name is required").max(20, "Name must be 20 characters or less"),
-  description: z.string().min(1).max(200, "Description must be 200 characters or less"),
+  description: z.string().min(1, "Description is required").max(200, "Description must be 200 characters or less"),
   programAreaId: z.string().min(1),
   ageGroup: z.enum(AGE_GROUPS)
 });

--- a/src/features/sessions/sections/useCreateActivity.ts
+++ b/src/features/sessions/sections/useCreateActivity.ts
@@ -13,7 +13,7 @@ export const CreateJamboreeActivityRequestSchema = z.strictObject({
   sectionId: z.uuid(),
   blockId: z.string().min(1),
   name: z.string().min(1, "Name is required").max(20, "Name must be 20 characters or less"),
-  description: z.string().min(1).max(200, "Description must be 200 characters or less").optional(),
+  description: z.string().min(1).max(200, "Description must be 200 characters or less"),
   programAreaId: z.never().optional(),
   ageGroup: z.never().optional(),
 });
@@ -24,7 +24,7 @@ export const CreateBundleActivityRequestSchema = z.strictObject({
   sectionId: z.uuid(),
   blockId: z.string().min(1),
   name: z.string().min(1, "Name is required").max(20, "Name must be 20 characters or less"),
-  description: z.string().min(1).max(200, "Description must be 200 characters or less").optional(),
+  description: z.string().min(1).max(200, "Description must be 200 characters or less"),
   programAreaId: z.string().min(1),
   ageGroup: z.enum(AGE_GROUPS)
 });

--- a/src/features/sessions/sections/useCreateActivity.ts
+++ b/src/features/sessions/sections/useCreateActivity.ts
@@ -12,8 +12,8 @@ export const CreateJamboreeActivityRequestSchema = z.strictObject({
   sessionId: z.uuid(),
   sectionId: z.uuid(),
   blockId: z.string().min(1),
-  name: z.string().min(1),
-  description: z.string().min(1),
+  name: z.string().min(1, "Name is required").max(20, "Name must be 20 characters or less"),
+  description: z.string().min(1).max(200, "Description must be 200 characters or less").optional(),
   programAreaId: z.never().optional(),
   ageGroup: z.never().optional(),
 });
@@ -23,8 +23,8 @@ export const CreateBundleActivityRequestSchema = z.strictObject({
   sessionId: z.uuid(),
   sectionId: z.uuid(),
   blockId: z.string().min(1),
-  name: z.string().min(1),
-  description: z.string().min(1),
+  name: z.string().min(1, "Name is required").max(20, "Name must be 20 characters or less"),
+  description: z.string().min(1).max(200, "Description must be 200 characters or less").optional(),
   programAreaId: z.string().min(1),
   ageGroup: z.enum(AGE_GROUPS)
 });

--- a/src/features/sessions/sections/useCreateActivity.ts
+++ b/src/features/sessions/sections/useCreateActivity.ts
@@ -1,11 +1,11 @@
 import { db } from "@/config/firebase";
-import { getProgramAreaDoc, listProgramAreaDocs } from "@/data/firestore/programAreas";
+import { getProgramAreaDoc } from "@/data/firestore/programAreas";
 import { getSectionScheduleDoc, updateSectionScheduleDoc } from "@/data/firestore/sectionSchedules";
 import { isBundleSectionSchedule, isBunkJamboreeSectionSchedule } from "@/types/scheduling/schedulingTypeGuards";
 import { BundleActivityWithAssignments, BunkJamboreeActivityWithAssignments, NonBunkJamboreeActivityWithAssignments } from "@/types/scheduling/schedulingTypes";
 import { AGE_GROUPS } from "@/types/sessions/sessionTypes";
 import { useMutation } from "@tanstack/react-query";
-import { arrayUnion, documentId, runTransaction, Transaction } from "firebase/firestore";
+import { arrayUnion, runTransaction, Transaction } from "firebase/firestore";
 import { v4 as uuidv4 } from "uuid";
 import z from "zod";
 

--- a/src/features/sessions/sections/useCreateActivity.ts
+++ b/src/features/sessions/sections/useCreateActivity.ts
@@ -1,0 +1,89 @@
+import { db } from "@/config/firebase";
+import { getSectionScheduleDoc, updateSectionScheduleDoc } from "@/data/firestore/sectionSchedules";
+import { isBundleSectionSchedule, isBunkJamboreeSectionSchedule } from "@/types/scheduling/schedulingTypeGuards";
+import { BundleActivityWithAssignments, BunkJamboreeActivityWithAssignments, NonBunkJamboreeActivityWithAssignments } from "@/types/scheduling/schedulingTypes";
+import { AGE_GROUPS } from "@/types/sessions/sessionTypes";
+import { useMutation } from "@tanstack/react-query";
+import { arrayUnion, runTransaction, Transaction } from "firebase/firestore";
+import { v4 as uuidv4 } from "uuid";
+import z from "zod";
+
+const CreateJamboreeActivityRequestSchema = z.strictObject({
+  sessionId: z.uuid(),
+  sectionId: z.uuid(),
+  blockId: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1),
+});
+export type CreateJamboreeActivityRequest = z.infer<typeof CreateJamboreeActivityRequestSchema>;
+
+const CreateBundleActivityRequestSchema = z.strictObject({
+  sessionId: z.uuid(),
+  sectionId: z.uuid(),
+  blockId: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1),
+  programAreaId: z.string().min(1),
+  ageGroup: z.enum(AGE_GROUPS)
+});
+export type CreateBundleActivityRequest = z.infer<typeof CreateBundleActivityRequestSchema>;
+
+const CreateActivityRequestSchema = z.union([CreateJamboreeActivityRequestSchema, CreateBundleActivityRequestSchema]);
+export type CreateActivityRequest = z.infer<typeof CreateActivityRequestSchema>;
+
+async function createActivity(req: CreateActivityRequest) {
+  await runTransaction(db, async (transaction: Transaction) => {
+    const sectionSchedule = await getSectionScheduleDoc(req.sessionId, req.sectionId, transaction);
+    if (isBundleSectionSchedule(sectionSchedule)) {
+      const inputValidationResult = CreateBundleActivityRequestSchema.safeParse(req);
+      if (!inputValidationResult.success) {
+        throw new Error("Invalid input");
+      }
+      const { sessionId, sectionId, blockId, ...rest } = inputValidationResult.data;
+      if (sectionSchedule.blocks[blockId].activities.some((act) => act.programAreaId === rest.programAreaId)) {
+        throw new Error("Cannot have multiple activities in the same block and program area");
+      }
+      await updateSectionScheduleDoc(sessionId, sectionId, {
+        [`blocks.${blockId}.activities`]: arrayUnion({
+          id: uuidv4(),
+          camperIds: [],
+          staffIds: [],
+          adminIds: [],
+          ...rest,
+        } satisfies BundleActivityWithAssignments)
+      }, transaction);
+    } else {
+      const inputValidationResult = CreateJamboreeActivityRequestSchema.safeParse(req);
+      if (!inputValidationResult.success) {
+        throw new Error("Invalid input");
+      }
+      const { sessionId, sectionId, blockId, ...rest } = inputValidationResult.data;
+      if (sectionSchedule.blocks[blockId].activities.some((act) => act.name === rest.name)) {
+        throw new Error("Cannot have multiple activities in the same block with the same name");
+      }
+      await updateSectionScheduleDoc(sessionId, sectionId, {
+        [`blocks.${blockId}.activities`]: arrayUnion(isBunkJamboreeSectionSchedule(sectionSchedule) ? {
+          id: uuidv4(),
+          bunkNums: [],
+          adminIds: [],
+          ...rest,
+        } satisfies BunkJamboreeActivityWithAssignments : {
+          id: uuidv4(),
+          camperIds: [],
+          staffIds: [],
+          adminIds: [],
+          ...rest
+        } satisfies NonBunkJamboreeActivityWithAssignments)
+      }, transaction);
+    }
+  })
+}
+
+export default function useCreateActivity() {
+  return useMutation({
+    mutationFn: (req: CreateActivityRequest) => createActivity(req),
+    onSuccess: (_data, { sessionId, sectionId }, _result, { client }) => {
+      client.invalidateQueries({ queryKey: ['sessions', sessionId, 'sections', sectionId, 'schedule'] });
+    }
+  })
+}

--- a/src/features/sessions/sections/useCreateActivity.ts
+++ b/src/features/sessions/sections/useCreateActivity.ts
@@ -1,10 +1,11 @@
 import { db } from "@/config/firebase";
+import { getProgramAreaDoc, listProgramAreaDocs } from "@/data/firestore/programAreas";
 import { getSectionScheduleDoc, updateSectionScheduleDoc } from "@/data/firestore/sectionSchedules";
 import { isBundleSectionSchedule, isBunkJamboreeSectionSchedule } from "@/types/scheduling/schedulingTypeGuards";
 import { BundleActivityWithAssignments, BunkJamboreeActivityWithAssignments, NonBunkJamboreeActivityWithAssignments } from "@/types/scheduling/schedulingTypes";
 import { AGE_GROUPS } from "@/types/sessions/sessionTypes";
 import { useMutation } from "@tanstack/react-query";
-import { arrayUnion, runTransaction, Transaction } from "firebase/firestore";
+import { arrayUnion, documentId, runTransaction, Transaction } from "firebase/firestore";
 import { v4 as uuidv4 } from "uuid";
 import z from "zod";
 
@@ -44,6 +45,10 @@ async function createActivity(req: CreateActivityRequest) {
       const { sessionId, sectionId, blockId, ...rest } = inputValidationResult.data;
       if (sectionSchedule.blocks[blockId].activities.some((act) => act.programAreaId === rest.programAreaId)) {
         throw new Error("Cannot have multiple activities in the same block and program area");
+      }
+      const programArea = await getProgramAreaDoc(rest.programAreaId, transaction);
+      if (programArea.isDeleted) {
+        throw new Error("Program area does not exist");
       }
       await updateSectionScheduleDoc(sessionId, sectionId, {
         [`blocks.${blockId}.activities`]: arrayUnion({

--- a/src/features/sessions/sections/useCreateActivity.ts
+++ b/src/features/sessions/sections/useCreateActivity.ts
@@ -8,16 +8,18 @@ import { arrayUnion, runTransaction, Transaction } from "firebase/firestore";
 import { v4 as uuidv4 } from "uuid";
 import z from "zod";
 
-const CreateJamboreeActivityRequestSchema = z.strictObject({
+export const CreateJamboreeActivityRequestSchema = z.strictObject({
   sessionId: z.uuid(),
   sectionId: z.uuid(),
   blockId: z.string().min(1),
   name: z.string().min(1),
   description: z.string().min(1),
+  programAreaId: z.never().optional(),
+  ageGroup: z.never().optional(),
 });
 export type CreateJamboreeActivityRequest = z.infer<typeof CreateJamboreeActivityRequestSchema>;
 
-const CreateBundleActivityRequestSchema = z.strictObject({
+export const CreateBundleActivityRequestSchema = z.strictObject({
   sessionId: z.uuid(),
   sectionId: z.uuid(),
   blockId: z.string().min(1),
@@ -28,7 +30,7 @@ const CreateBundleActivityRequestSchema = z.strictObject({
 });
 export type CreateBundleActivityRequest = z.infer<typeof CreateBundleActivityRequestSchema>;
 
-const CreateActivityRequestSchema = z.union([CreateJamboreeActivityRequestSchema, CreateBundleActivityRequestSchema]);
+export const CreateActivityRequestSchema = z.union([CreateJamboreeActivityRequestSchema, CreateBundleActivityRequestSchema]);
 export type CreateActivityRequest = z.infer<typeof CreateActivityRequestSchema>;
 
 async function createActivity(req: CreateActivityRequest) {

--- a/src/features/sessions/sections/useCreateActivity.ts
+++ b/src/features/sessions/sections/useCreateActivity.ts
@@ -26,7 +26,7 @@ export const CreateBundleActivityRequestSchema = z.strictObject({
   blockId: z.string().min(1),
   name: z.string().min(1, "Name is required").max(20, "Name must be 20 characters or less"),
   description: z.string().min(1, "Description is required").max(200, "Description must be 200 characters or less"),
-  programAreaId: z.string().min(1),
+  programAreaId: z.string("Program area is required").min(1),
   ageGroup: z.enum(AGE_GROUPS)
 });
 export type CreateBundleActivityRequest = z.infer<typeof CreateBundleActivityRequestSchema>;

--- a/src/hooks/programAreas/useProgramAreaList.ts
+++ b/src/hooks/programAreas/useProgramAreaList.ts
@@ -1,0 +1,34 @@
+import { listProgramAreaDocs } from "@/data/firestore/programAreas";
+import { ProgramAreaDoc } from "@/data/firestore/types/documents";
+import { FirestoreQueryOptions } from "@/data/firestore/types/queries";
+import { ProgramArea } from "@/types/scheduling/schedulingTypes";
+import { infiniteQueryOptions, useInfiniteQuery } from "@tanstack/react-query";
+import { TanstackQueryFirestorePageParam } from "../types/tanstackQueryTypes";
+
+export function getUseProgramAreaListOptions(firestoreQueryOptions: FirestoreQueryOptions<ProgramAreaDoc> = {}) {
+  return infiniteQueryOptions({
+    queryKey: ['programAreas', firestoreQueryOptions],
+    queryFn: async ({ pageParam, client }) => {
+      const updatedQueryOptions = firestoreQueryOptions ? { ...firestoreQueryOptions } : {};
+      if (pageParam) {
+        if (pageParam.direction === 'next') {
+          updatedQueryOptions.startAfter = pageParam.snapshot;
+          updatedQueryOptions.startAt = undefined;
+        } else {
+          updatedQueryOptions.endBefore = pageParam.snapshot;
+          updatedQueryOptions.endAt = undefined;
+        }
+      }
+      const programAreasPage = await listProgramAreaDocs(updatedQueryOptions);
+      programAreasPage.docs.forEach((programArea: ProgramArea) => client.setQueryData(['programAreas', programArea.id], programArea));
+      return programAreasPage;
+    },
+    initialPageParam: undefined as TanstackQueryFirestorePageParam<ProgramAreaDoc> | undefined,
+    getPreviousPageParam: (firstPage) => firstPage.firstSnapshot ? ({ direction: 'previous' as const, snapshot: firstPage.firstSnapshot }) : undefined,
+    getNextPageParam: (lastPage) => lastPage.lastSnapshot ? ({ direction: 'next' as const, snapshot: lastPage.lastSnapshot }) : undefined,
+  });
+}
+
+export default function useProgramAreaList(firestoreQueryOptions: FirestoreQueryOptions<ProgramAreaDoc> = {}) {
+  return useInfiniteQuery(getUseProgramAreaListOptions(firestoreQueryOptions));
+}

--- a/src/hooks/programAreas/useProgramAreaList.ts
+++ b/src/hooks/programAreas/useProgramAreaList.ts
@@ -26,6 +26,7 @@ export function getUseProgramAreaListOptions(firestoreQueryOptions: FirestoreQue
     initialPageParam: undefined as TanstackQueryFirestorePageParam<ProgramAreaDoc> | undefined,
     getPreviousPageParam: (firstPage) => firstPage.firstSnapshot ? ({ direction: 'previous' as const, snapshot: firstPage.firstSnapshot }) : undefined,
     getNextPageParam: (lastPage) => lastPage.lastSnapshot ? ({ direction: 'next' as const, snapshot: lastPage.lastSnapshot }) : undefined,
+    select: (data) => data.pages.flatMap(page => page.docs),
   });
 }
 

--- a/src/hooks/schedules/useSectionSchedule.ts
+++ b/src/hooks/schedules/useSectionSchedule.ts
@@ -1,13 +1,17 @@
 import { getSectionScheduleDoc } from "@/data/firestore/sectionSchedules";
 import { queryOptions, skipToken, useQuery } from "@tanstack/react-query";
 
-export function sectionScheduleQueryOptions(sessionId: string | undefined, sectionId: string | undefined, enabled: boolean = true) {
+export function sectionScheduleQueryOptions(sessionId: string, sectionId: string) {
   return queryOptions({
     queryKey: ['sessions', sessionId, 'sections', sectionId, 'schedule'],
-    queryFn: sessionId && sectionId && enabled ? (() => getSectionScheduleDoc(sessionId, sectionId)) : skipToken
+    queryFn: () => getSectionScheduleDoc(sessionId, sectionId)
   });
 }
 
-export default function useSectionSchedule(sessionId: string | undefined, sectionId: string | undefined, enabled: boolean = true) {
-  return useQuery(sectionScheduleQueryOptions(sessionId, sectionId, enabled));
+export default function useSectionSchedule(sessionId: string, sectionId: string, enabled: boolean = true) {
+  const defaultOptions = sectionScheduleQueryOptions(sessionId, sectionId);
+  return useQuery({
+    ...defaultOptions,
+    queryFn: enabled ? defaultOptions.queryFn : skipToken
+  });
 }

--- a/src/hooks/schedules/useSectionSchedule.ts
+++ b/src/hooks/schedules/useSectionSchedule.ts
@@ -1,7 +1,7 @@
 import { getSectionScheduleDoc } from "@/data/firestore/sectionSchedules";
 import { queryOptions, skipToken, useQuery } from "@tanstack/react-query";
 
-export function getUseSectionScheduleOptions(sessionId: string | undefined, sectionId: string | undefined, enabled: boolean = true) {
+export function sectionScheduleQueryOptions(sessionId: string | undefined, sectionId: string | undefined, enabled: boolean = true) {
   return queryOptions({
     queryKey: ['sessions', sessionId, 'sections', sectionId, 'schedule'],
     queryFn: sessionId && sectionId && enabled ? (() => getSectionScheduleDoc(sessionId, sectionId)) : skipToken
@@ -9,5 +9,5 @@ export function getUseSectionScheduleOptions(sessionId: string | undefined, sect
 }
 
 export default function useSectionSchedule(sessionId: string | undefined, sectionId: string | undefined, enabled: boolean = true) {
-  return useQuery(getUseSectionScheduleOptions(sessionId, sectionId, enabled));
+  return useQuery(sectionScheduleQueryOptions(sessionId, sectionId, enabled));
 }

--- a/src/styles/components/SelectThemeExtension.ts
+++ b/src/styles/components/SelectThemeExtension.ts
@@ -4,6 +4,7 @@ const SelectThemeExtension = Select.extend({
   classNames: {
     wrapper: 'max-w-80',
     input: 'border-blue border-2 rounded-sm max-h-30 overflow-y-scroll',
+    label: 'text-neutral-5 text-xl font-medium',
     dropdown: "rounded-sm border-neutral border p-0",
     option: "hover:bg-neutral-3 active:bg-neutral-4 rounded-none nth-2:rounded-t-sm last:rounded-b-sm not-last:border-b not-last:border-b-neutral-4",
   }

--- a/src/styles/components/TextareaThemeExtension.ts
+++ b/src/styles/components/TextareaThemeExtension.ts
@@ -2,7 +2,8 @@ import { Textarea } from "@mantine/core";
 
 const TextareaThemeExtension = Textarea.extend({
   classNames: {
-        input: "bg-blue-0 rounded-md border-none hover:border-neutral-8 px-3 hover:border-2 py-2 text-sm text-blue-9 placeholder:text-neutral-5",
+    label: 'text-neutral-5 text-xl font-medium',
+    input: "bg-blue-0 rounded-md border-none hover:border-neutral-8 px-3 hover:border-2 py-2 text-sm text-blue-9 placeholder:text-neutral-5",
   }
 });
 


### PR DESCRIPTION
- Created `useCreateActivity` hook that handles activity creation
- Created `CreateActivityModal` that allows users to create activities
  - Integrated with Tanstack Form for easier validation, state management, and submission handling
  - Added modal trigger to a new add button on each block's row of the section schedule
- Standardized label styling across different input components