### PR TITLE
feat(attendees): add functionality to assign staffers as program counselors

### DIFF
--- a/src/app/sessions/[sessionId]/directory/DirectoryTableView.tsx
+++ b/src/app/sessions/[sessionId]/directory/DirectoryTableView.tsx
@@ -209,9 +209,19 @@ export default function DirectoryTableView({
           cell: (info) => renderIdListAsNames(info.getValue<number[]>()),
         },
         {
-          accessorFn: (row) => (row as StaffAttendee).programCounselorFor,
+          accessorFn: (row) =>
+            (row as StaffAttendee).programCounselorFor ?? "N/A",
           header: "Program Counselor",
-          cell: (info) => render(info.getValue()),
+          cell: (info) => (
+            <Select
+              value={info.getValue() as string | null}
+              data={programAreasQuery.data?.map((area) => area.id)}
+              placeholder="N/A"
+              onChange={(val) => {
+                if (!val) return;
+              }}
+            />
+          ),
         },
         {
           accessorKey: "leadBunkCounselor",
@@ -234,21 +244,6 @@ export default function DirectoryTableView({
               dates.map((d) => moment(d).format("MM-YYYY")).join(", "),
             );
           },
-        },
-        {
-          accessorFn: (row) =>
-            (row as StaffAttendee).programCounselorFor ?? "N/A",
-          header: "Program Counselor",
-          cell: (info) => (
-            <Select
-              value={info.getValue() as string | null}
-              data={programAreasQuery.data?.map((area) => area.id)}
-              placeholder="N/A"
-              onChange={(val) => {
-                if (!val) return;
-              }}
-            />
-          ),
         },
       ];
     }

--- a/src/app/sessions/[sessionId]/directory/DirectoryTableView.tsx
+++ b/src/app/sessions/[sessionId]/directory/DirectoryTableView.tsx
@@ -36,6 +36,8 @@ import LoadingPage from "@/app/loading";
 import useDaysOffSchedule from "@/hooks/daysOffSchedules/useDaysOffSchedule";
 import useSession from "@/hooks/sessions/useSession";
 import openAddAttendeesModal from "@/components/AddAttendeesModal/AddAttendeesModal";
+import { programAreaListQueryOptions } from "@/hooks/programAreas/useProgramAreaList";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 type LargeDirectoryBlockProps = {
   sessionId: string;
@@ -46,6 +48,11 @@ export default function DirectoryTableView({
   const { data: attendeeData, isLoading, isError } = useAttendeeList(sessionId);
   const daysOffScheduleQuery = useDaysOffSchedule(sessionId);
   const sessionQuery = useSession(sessionId);
+  const programAreasQuery = useInfiniteQuery(
+    programAreaListQueryOptions({
+      where: [{ fieldPath: "isDeleted", operation: "==", value: false }],
+    }),
+  );
 
   const [selectedRole, setSelectedRole] = useState<AttendeeRole>("CAMPER");
   const [sortNameOption, setSortNameOption] = useState<string | null>(null);

--- a/src/app/sessions/[sessionId]/directory/DirectoryTableView.tsx
+++ b/src/app/sessions/[sessionId]/directory/DirectoryTableView.tsx
@@ -235,6 +235,21 @@ export default function DirectoryTableView({
             );
           },
         },
+        {
+          accessorFn: (row) =>
+            (row as StaffAttendee).programCounselorFor ?? "N/A",
+          header: "Program Counselor",
+          cell: (info) => (
+            <Select
+              value={info.getValue() as string | null}
+              data={programAreasQuery.data?.map((area) => area.id)}
+              placeholder="N/A"
+              onChange={(val) => {
+                if (!val) return;
+              }}
+            />
+          ),
+        },
       ];
     }
 

--- a/src/app/sessions/[sessionId]/directory/DirectoryTableView.tsx
+++ b/src/app/sessions/[sessionId]/directory/DirectoryTableView.tsx
@@ -38,6 +38,7 @@ import useSession from "@/hooks/sessions/useSession";
 import openAddAttendeesModal from "@/components/AddAttendeesModal/AddAttendeesModal";
 import { programAreaListQueryOptions } from "@/hooks/programAreas/useProgramAreaList";
 import { useInfiniteQuery } from "@tanstack/react-query";
+import useSetProgramCounselorArea from "@/features/sessions/attendees/hooks/useSetProgramCounselorArea";
 
 type LargeDirectoryBlockProps = {
   sessionId: string;
@@ -53,6 +54,8 @@ export default function DirectoryTableView({
       where: [{ fieldPath: "isDeleted", operation: "==", value: false }],
     }),
   );
+
+  const setProgramCounselorAreaMutation = useSetProgramCounselorArea();
 
   const [selectedRole, setSelectedRole] = useState<AttendeeRole>("CAMPER");
   const [sortNameOption, setSortNameOption] = useState<string | null>(null);

--- a/src/app/sessions/[sessionId]/directory/DirectoryTableView.tsx
+++ b/src/app/sessions/[sessionId]/directory/DirectoryTableView.tsx
@@ -220,9 +220,13 @@ export default function DirectoryTableView({
               value={info.getValue() as string | null}
               data={programAreasQuery.data?.map((area) => area.id)}
               placeholder="N/A"
-              onChange={(val) => {
-                if (!val) return;
-              }}
+              onChange={(val) =>
+                setProgramCounselorAreaMutation.mutate({
+                  sessionId,
+                  stafferId: info.row.original.attendeeId,
+                  programAreaId: val,
+                })
+              }
             />
           ),
         },

--- a/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
+++ b/src/features/scheduling/activityManagement/components/CreateActivityModal/CreateActivityModal.tsx
@@ -3,10 +3,7 @@ import useCreateActivity, {
   CreateJamboreeActivityRequestSchema,
 } from "@/features/sessions/sections/useCreateActivity";
 import { sectionScheduleQueryOptions } from "@/hooks/schedules/useSectionSchedule";
-import {
-  AGE_GROUPS,
-  AgeGroup,
-} from "@/types/sessions/sessionTypes";
+import { AGE_GROUPS, AgeGroup } from "@/types/sessions/sessionTypes";
 import { Button, Radio, Select, Textarea, TextInput } from "@mantine/core";
 import { modals, openModal } from "@mantine/modals";
 import {
@@ -15,7 +12,7 @@ import {
 } from "@tanstack/react-query";
 import { useForm } from "@tanstack/react-form";
 import z from "zod";
-import { getUseProgramAreaListOptions } from "@/hooks/programAreas/useProgramAreaList";
+import { programAreaListQueryOptions } from "@/hooks/programAreas/useProgramAreaList";
 import { ErrorBoundary } from "react-error-boundary";
 import { Suspense } from "react";
 import LoadingPage from "@/app/loading";
@@ -53,16 +50,17 @@ function CreateActivityModal(props: CreateActivityModalProps) {
     sectionScheduleQueryOptions(sessionId, sectionId),
   );
   const programAreasQuery = useSuspenseInfiniteQuery(
-    getUseProgramAreaListOptions({
+    programAreaListQueryOptions({
       where: [{ fieldPath: "isDeleted", operation: "==", value: false }],
     }),
   );
 
   const createActivityMutation = useCreateActivity();
 
-  const validationSchema = sectionScheduleQuery.data.type === "BUNDLE"
-    ? CreateBundleActivityRequestSchema
-    : CreateJamboreeActivityRequestSchema;
+  const validationSchema =
+    sectionScheduleQuery.data.type === "BUNDLE"
+      ? CreateBundleActivityRequestSchema
+      : CreateJamboreeActivityRequestSchema;
 
   const form = useForm({
     defaultValues:
@@ -106,7 +104,8 @@ function CreateActivityModal(props: CreateActivityModalProps) {
         key="name"
         validators={{
           onBlur: ({ value }) => {
-            const validationResult = validationSchema.shape.name.safeParse(value);
+            const validationResult =
+              validationSchema.shape.name.safeParse(value);
             if (validationResult.success) return;
             return validationResult.error.issues
               .map((issue) => issue.message)
@@ -131,7 +130,8 @@ function CreateActivityModal(props: CreateActivityModalProps) {
         key="description"
         validators={{
           onBlur: ({ value }) => {
-            const validationResult = validationSchema.shape.description.safeParse(value);
+            const validationResult =
+              validationSchema.shape.description.safeParse(value);
             if (validationResult.success) return;
             return validationResult.error.issues
               .map((issue) => issue.message)

--- a/src/features/sessions/attendees/hooks/useSetProgramCounselorArea.ts
+++ b/src/features/sessions/attendees/hooks/useSetProgramCounselorArea.ts
@@ -27,6 +27,9 @@ async function setProgramCounselorArea(req: SetProgramCounselorAreaRequest) {
 
 export default function useSetProgramCounselorArea() {
   return useMutation({
-    mutationFn: (req: SetProgramCounselorAreaRequest) => setProgramCounselorArea(req)
+    mutationFn: (req: SetProgramCounselorAreaRequest) => setProgramCounselorArea(req),
+    onSuccess: (_data, { sessionId }, _result, { client }) => {
+      client.invalidateQueries({ queryKey: ['sessions', sessionId, 'attendees'] });
+    }
   })
 }

--- a/src/features/sessions/attendees/hooks/useSetProgramCounselorArea.ts
+++ b/src/features/sessions/attendees/hooks/useSetProgramCounselorArea.ts
@@ -1,0 +1,32 @@
+import { db } from "@/config/firebase";
+import { updateAttendeeDoc } from "@/data/firestore/attendees";
+import { getProgramAreaDoc } from "@/data/firestore/programAreas";
+import { useMutation } from "@tanstack/react-query";
+import { deleteField, runTransaction, Transaction } from "firebase/firestore";
+
+interface SetProgramCounselorAreaRequest {
+  sessionId: string;
+  stafferId: number;
+  programAreaId: string | null;
+}
+
+async function setProgramCounselorArea(req: SetProgramCounselorAreaRequest) {
+  const { sessionId, stafferId, programAreaId } = req;
+  if (programAreaId === null) {
+    await updateAttendeeDoc(stafferId, sessionId, { programCounselorFor: deleteField() });
+    return;
+  }
+  await runTransaction(db, async (transaction: Transaction) => {
+    const programArea = await getProgramAreaDoc(programAreaId, transaction);
+    if (programArea.isDeleted) {
+      throw new Error("The selected program area does not exist.");
+    }
+    await updateAttendeeDoc(stafferId, sessionId, { programCounselorFor: programAreaId }, transaction);
+  });
+}
+
+export default function useSetProgramCounselorArea() {
+  return useMutation({
+    mutationFn: (req: SetProgramCounselorAreaRequest) => setProgramCounselorArea(req)
+  })
+}

--- a/src/hooks/programAreas/useProgramAreaList.ts
+++ b/src/hooks/programAreas/useProgramAreaList.ts
@@ -5,7 +5,7 @@ import { ProgramArea } from "@/types/scheduling/schedulingTypes";
 import { infiniteQueryOptions, useInfiniteQuery } from "@tanstack/react-query";
 import { TanstackQueryFirestorePageParam } from "../types/tanstackQueryTypes";
 
-export function getUseProgramAreaListOptions(firestoreQueryOptions: FirestoreQueryOptions<ProgramAreaDoc> = {}) {
+export function programAreaListQueryOptions(firestoreQueryOptions: FirestoreQueryOptions<ProgramAreaDoc> = {}) {
   return infiniteQueryOptions({
     queryKey: ['programAreas', firestoreQueryOptions],
     queryFn: async ({ pageParam, client }) => {
@@ -31,5 +31,5 @@ export function getUseProgramAreaListOptions(firestoreQueryOptions: FirestoreQue
 }
 
 export default function useProgramAreaList(firestoreQueryOptions: FirestoreQueryOptions<ProgramAreaDoc> = {}) {
-  return useInfiniteQuery(getUseProgramAreaListOptions(firestoreQueryOptions));
+  return useInfiniteQuery(programAreaListQueryOptions(firestoreQueryOptions));
 }


### PR DESCRIPTION
- Modify `Program Counselor` column in the staff directory table to render as a `Select` component
  - When a user picks a new value or removes the value, the respective staffer's program counselor area will be updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Staff can assign or remove a program area for each Program Counselor directly from the session directory.
  - Program Counselor assignments now display the selected area, or “N/A” when none is assigned.
  - Only active program areas are available for assignment.
- **Improvements**
  - Program area selection is now supported consistently when creating activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->