### PR TITLE
refactor(data-fetching): flatten infinite data lists fetched from Firestore

### DIFF
--- a/src/app/albums/AlbumsPage.tsx
+++ b/src/app/albums/AlbumsPage.tsx
@@ -69,7 +69,7 @@ export default function AlbumsPage() {
     return <LoadingPage />;
   }
 
-  const albums = albumsQuery.data?.pages.flatMap((page) => page.docs) ?? [];
+  const albums = albumsQuery.data ?? [];
   return (
     <div className="flex flex-col w-6/7 grow mx-auto px-4 py-6 gap-6">
       <div className="flex items-center justify-between">

--- a/src/app/albums/[albumId]/AlbumPage.tsx
+++ b/src/app/albums/[albumId]/AlbumPage.tsx
@@ -103,8 +103,7 @@ export function AlbumPageContent(props: AlbumPageContentProps) {
     return <ErrorPage error={albumItemsQuery.error} />;
   }
 
-  const albumItems =
-    albumItemsQuery.data.pages.flatMap((page) => page.docs) || [];
+  const albumItems = albumItemsQuery.data;
 
   return (
     <div className="flex flex-col w-6/7 grow mx-auto px-4 py-6 gap-6">

--- a/src/app/albums/[albumId]/pending/PendingPage.tsx
+++ b/src/app/albums/[albumId]/pending/PendingPage.tsx
@@ -78,9 +78,7 @@ export default function PendingPage(props: PendingPageProps) {
       </div>
     );
   } else {
-    const pendingAlbumItems = pendingAlbumItemsQuery.data.pages.flatMap(
-      (page) => page.docs,
-    );
+    const pendingAlbumItems = pendingAlbumItemsQuery.data;
     if (pendingAlbumItems.length === 0) {
       albumItemContent = (
         <div className="flex flex-col justify-center items-center grow bg-neutral-3 gap-4">

--- a/src/app/sessions/[sessionId]/SessionCalendar.tsx
+++ b/src/app/sessions/[sessionId]/SessionCalendar.tsx
@@ -30,7 +30,7 @@ export default function SessionCalendar(props: SessionCalendarProps) {
   } else if (sectionsQuery.isError) {
     return <ErrorPage error={sectionsQuery.error} />;
   } else {
-    return <SessionCalendarContent session={sessionQuery.data} sections={sectionsQuery.data.pages.flatMap(page => page.docs)} />;
+    return <SessionCalendarContent session={sessionQuery.data} sections={sectionsQuery.data} />;
   }
 }
 

--- a/src/app/sessions/[sessionId]/directory/DirectoryTableView.tsx
+++ b/src/app/sessions/[sessionId]/directory/DirectoryTableView.tsx
@@ -64,15 +64,10 @@ export default function DirectoryTableView({
   const [globalFilter, setGlobalFilter] = useState("");
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 });
 
-  const attendeeList = useMemo(
-    () => attendeeData?.pages.flatMap((page) => page.docs),
-    [attendeeData],
-  );
-
   const data: Attendee[] = useMemo(() => {
-    if (!attendeeList) return [];
+    if (!attendeeData) return [];
 
-    let attendeeArr = [...attendeeList];
+    let attendeeArr = [...attendeeData];
 
     if (selectedRole) {
       attendeeArr = attendeeArr.filter((a) => a.role === selectedRole);
@@ -101,15 +96,15 @@ export default function DirectoryTableView({
     }
 
     return attendeeArr;
-  }, [attendeeList, selectedRole, sortNameOption]);
+  }, [attendeeData, selectedRole, sortNameOption]);
 
   const getNameFromId = useCallback(
     (id: number) => {
-      const person = attendeeList?.find((a) => a.attendeeId === id);
+      const person = attendeeData?.find((a) => a.attendeeId === id);
       if (!person) return null;
       return `${person.snapshot.name.firstName} ${person.snapshot.name.lastName[0]}.`;
     },
-    [attendeeList],
+    [attendeeData],
   );
 
   const columns = useMemo<ColumnDef<Attendee>[]>(() => {

--- a/src/app/sessions/[sessionId]/directory/DirectoryTableView.tsx
+++ b/src/app/sessions/[sessionId]/directory/DirectoryTableView.tsx
@@ -308,6 +308,9 @@ export default function DirectoryTableView({
     getNameFromId,
     daysOffScheduleQuery,
     sessionQuery.data?.startDate,
+    programAreasQuery.data,
+    sessionId,
+    setProgramCounselorAreaMutation,
   ]);
 
   const table = useReactTable({

--- a/src/components/ActivityGrid.tsx
+++ b/src/components/ActivityGrid.tsx
@@ -43,7 +43,7 @@ export default function ActivityGrid(props: ActivityGridProps) {
     <ActivityGridContent
       schedule={scheduleQuery.data}
       section={sectionQuery.data}
-      attendees={attendeesQuery.data.pages.flatMap((page) => page.docs)}
+      attendees={attendeesQuery.data}
     />
   );
 }

--- a/src/components/NightScheduleTable.tsx
+++ b/src/components/NightScheduleTable.tsx
@@ -77,7 +77,7 @@ export default function NightScheduleTable(props: NightScheduleTableProps) {
     <NightScheduleTableContent
       daysOffSchedule={daysOffSchedule}
       session={session}
-      attendees={attendees.pages.flatMap(page => page.docs)}
+      attendees={attendees}
       nightShifts={nightShifts.docs}
     />
   );

--- a/src/components/SessionsPage.tsx
+++ b/src/components/SessionsPage.tsx
@@ -26,7 +26,7 @@ export default function SessionsPage() {
     orderBy: [{ fieldPath: "startDate", direction: "desc" }],
     limit: 10,
   });
-  const sessions = sessionsQuery.data?.pages.flatMap((page) => page.docs) ?? [];
+  const sessions = sessionsQuery.data ?? [];
 
   const { ref, inViewport } = useInViewport();
   const { hasNextPage, isFetchingNextPage, fetchNextPage } = sessionsQuery;

--- a/src/components/SmallDirectoryBlock.tsx
+++ b/src/components/SmallDirectoryBlock.tsx
@@ -65,8 +65,7 @@ export function SmallDirectoryBlock({ sessionId }: SmallDirectoryBlockProps) {
   const usersToBunk = useMemo(() => {
     if (!bunksQuery.data) return [];
     const usersToBunk: { [userId: number]: number } = {};
-    bunksQuery.data.pages
-      .flatMap((page) => page.docs)
+    bunksQuery.data
       .forEach((bunk) => {
         [...bunk.camperIds, ...bunk.counselorIds].forEach(
           (userId) => (usersToBunk[userId] = bunk.bunkNum),

--- a/src/features/scheduling/exporting/DownloadDaySchedulePDFButton.tsx
+++ b/src/features/scheduling/exporting/DownloadDaySchedulePDFButton.tsx
@@ -74,7 +74,7 @@ export default function DownloadDaySchedulePDFButton(
   }
   return (
     <DownloadDaySchedulePDFButtonContent
-      attendees={attendeesQuery.data.pages.flatMap(page => page.docs)}
+      attendees={attendeesQuery.data}
       section={sectionQuery.data}
       schedule={scheduleQuery.data}
       freeplay={freeplayQuery.data}

--- a/src/features/scheduling/generation/generateFreeplaySchedule.ts
+++ b/src/features/scheduling/generation/generateFreeplaySchedule.ts
@@ -6,7 +6,7 @@ import { Moment } from "moment";
 import { useMutation } from "@tanstack/react-query";
 import { getUseAttendeeListOptions } from "@/hooks/attendees/useAttendeeList";
 import { getUseFreeplayListOptions } from "@/hooks/freeplays/useFreeplayList";
-import { getUsePostListOptions } from "@/hooks/posts/usePostList";
+import { postListQueryOptions } from "@/hooks/posts/usePostList";
 
 interface UseGenerateFreeplayScheduleRequest {
   sessionId: string;
@@ -19,7 +19,7 @@ export default function useGenerateFreeplaySchedule() {
       const { sessionId, date } = req;
 
       const attendees = (await client.ensureInfiniteQueryData(getUseAttendeeListOptions(sessionId))).pages.flatMap(page => page.docs);
-      const posts = (await client.ensureInfiniteQueryData(getUsePostListOptions())).pages.flatMap(page => page.docs);
+      const posts = (await client.ensureInfiniteQueryData(postListQueryOptions())).pages.flatMap(page => page.docs);
       const otherFreeplaysInSession = (await client.ensureInfiniteQueryData(getUseFreeplayListOptions(sessionId, {
         where: [{ fieldPath: '__name__', operation: "!=", value: date.format("YYYY-MM-DD") }]
       }))).pages.flatMap(page => page.docs);
@@ -161,7 +161,7 @@ export function generateFreeplaySchedule(req: GenerateFreeplayScheduleRequest): 
   }
 
   const buddyAssignments: Freeplay["buddies"] = {};
-  let camperGroupsWithBuddyCandidates = camperGroups.map(camperGroup => ({camperGroup, buddyCandidates: typeof camperGroup === "number" ? buddyCandidatesById[camperGroup] : camperGroup.reduce((prev, camperId) => prev.union(buddyCandidatesById[camperId]), new Set<number>())}))
+  let camperGroupsWithBuddyCandidates = camperGroups.map(camperGroup => ({ camperGroup, buddyCandidates: typeof camperGroup === "number" ? buddyCandidatesById[camperGroup] : camperGroup.reduce((prev, camperId) => prev.union(buddyCandidatesById[camperId]), new Set<number>()) }))
   const numEmployeesToAssign = unassignedAdminIds.length + unassignedStaffIds.length;
   const unassignedEmployeeIds: number[] = [];
   for (let i = 0; i < numEmployeesToAssign; i++) {

--- a/src/features/sessions/postManagement/components/PostsPage.tsx
+++ b/src/features/sessions/postManagement/components/PostsPage.tsx
@@ -1,0 +1,8 @@
+import { postListQueryOptions } from "@/hooks/posts/usePostList";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
+
+export default function PostsPage() {
+  const postsQuery = useSuspenseInfiniteQuery(postListQueryOptions());
+
+  return <div>{postsQuery.data.map(x => x.id)}</div>
+}

--- a/src/features/sessions/postManagement/components/PostsPage.tsx
+++ b/src/features/sessions/postManagement/components/PostsPage.tsx
@@ -1,8 +1,0 @@
-import { postListQueryOptions } from "@/hooks/posts/usePostList";
-import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
-
-export default function PostsPage() {
-  const postsQuery = useSuspenseInfiniteQuery(postListQueryOptions());
-
-  return <div>{postsQuery.data.map(x => x.id)}</div>
-}

--- a/src/hooks/albumItems/useAlbumItemList.ts
+++ b/src/hooks/albumItems/useAlbumItemList.ts
@@ -4,6 +4,7 @@ import { AlbumItem } from "@/types/albums/albumTypes";
 import { infiniteQueryOptions, useInfiniteQuery } from "@tanstack/react-query";
 import { TanstackQueryFirestorePageParam } from "../types/tanstackQueryTypes";
 import { FirestoreQueryOptions } from "@/data/firestore/types/queries";
+import { flattenFirestoreInfiniteData } from "../utils";
 
 export function getUseAlbumItemListOptions(albumId: string, firestoreQueryOptions?: FirestoreQueryOptions<AlbumItemDoc>, enabled: boolean = true) {
   return infiniteQueryOptions({
@@ -26,7 +27,8 @@ export function getUseAlbumItemListOptions(albumId: string, firestoreQueryOption
     initialPageParam: undefined as TanstackQueryFirestorePageParam<AlbumItemDoc> | undefined,
     getPreviousPageParam: (firstPage) => firstPage.firstSnapshot ? ({ direction: 'previous' as const, snapshot: firstPage.firstSnapshot }) : undefined,
     getNextPageParam: (lastPage) => lastPage.lastSnapshot ? ({ direction: 'next' as const, snapshot: lastPage.lastSnapshot }) : undefined,
-    enabled
+    enabled,
+    select: flattenFirestoreInfiniteData
   });
 }
 

--- a/src/hooks/albums/useAlbumList.ts
+++ b/src/hooks/albums/useAlbumList.ts
@@ -4,6 +4,7 @@ import { AlbumDoc } from "@/data/firestore/types/documents";
 import { Album } from "@/types/albums/albumTypes";
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { TanstackQueryFirestorePageParam } from "../types/tanstackQueryTypes";
+import { flattenFirestoreInfiniteData } from "../utils";
 
 export default function useAlbumList(queryOptions?: FirestoreQueryOptions<AlbumDoc>) {
   const queryClient = useQueryClient();
@@ -27,5 +28,6 @@ export default function useAlbumList(queryOptions?: FirestoreQueryOptions<AlbumD
     initialPageParam: undefined as TanstackQueryFirestorePageParam<AlbumDoc> | undefined,
     getPreviousPageParam: (firstPage) => firstPage.firstSnapshot ? ({ direction: 'previous' as const, snapshot: firstPage.firstSnapshot }) : undefined,
     getNextPageParam: (lastPage) => lastPage.lastSnapshot ? ({ direction: 'next' as const, snapshot: lastPage.lastSnapshot }) : undefined,
+    select: flattenFirestoreInfiniteData
   });
 }

--- a/src/hooks/attendees/useAttendeeList.ts
+++ b/src/hooks/attendees/useAttendeeList.ts
@@ -4,6 +4,7 @@ import { FirestoreQueryOptions } from "@/data/firestore/types/queries";
 import { Attendee } from "@/types/sessions/sessionTypes";
 import { infiniteQueryOptions, useInfiniteQuery } from "@tanstack/react-query";
 import { TanstackQueryFirestorePageParam } from "../types/tanstackQueryTypes";
+import { flattenFirestoreInfiniteData } from "../utils";
 
 export function getUseAttendeeListOptions(sessionId: string, firestoreQueryOptions: FirestoreQueryOptions<AttendeeDoc> = {}) {
   return infiniteQueryOptions({
@@ -26,6 +27,7 @@ export function getUseAttendeeListOptions(sessionId: string, firestoreQueryOptio
     initialPageParam: undefined as TanstackQueryFirestorePageParam<AttendeeDoc> | undefined,
     getPreviousPageParam: (firstPage) => firstPage.firstSnapshot ? ({ direction: 'previous' as const, snapshot: firstPage.firstSnapshot }) : undefined,
     getNextPageParam: (lastPage) => lastPage.lastSnapshot ? ({ direction: 'next' as const, snapshot: lastPage.lastSnapshot }) : undefined,
+    select: flattenFirestoreInfiniteData
   });
 }
 

--- a/src/hooks/bunks/useBunkList.ts
+++ b/src/hooks/bunks/useBunkList.ts
@@ -4,6 +4,7 @@ import { Bunk } from "@/types/sessions/sessionTypes";
 import { infiniteQueryOptions, skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import { TanstackQueryFirestorePageParam } from "../types/tanstackQueryTypes";
 import { listBunkDocs } from "@/data/firestore/bunks";
+import { flattenFirestoreInfiniteData } from "../utils";
 
 export function getUseBunkListOptions(sessionId: string, firestoreQueryOptions: FirestoreQueryOptions<BunkDoc> = {}, enabled: boolean = true) {
   return infiniteQueryOptions({
@@ -25,7 +26,8 @@ export function getUseBunkListOptions(sessionId: string, firestoreQueryOptions: 
     }) : skipToken,
     initialPageParam: undefined as TanstackQueryFirestorePageParam<BunkDoc> | undefined,
     getPreviousPageParam: (firstPage) => firstPage.firstSnapshot ? ({ direction: 'previous' as const, snapshot: firstPage.firstSnapshot }) : undefined,
-    getNextPageParam: (lastPage) => lastPage.lastSnapshot ? ({ direction: 'next' as const, snapshot: lastPage.lastSnapshot }) : undefined
+    getNextPageParam: (lastPage) => lastPage.lastSnapshot ? ({ direction: 'next' as const, snapshot: lastPage.lastSnapshot }) : undefined,
+    select: flattenFirestoreInfiniteData
   });
 }
 

--- a/src/hooks/freeplays/useFreeplayList.ts
+++ b/src/hooks/freeplays/useFreeplayList.ts
@@ -4,6 +4,7 @@ import { FirestoreQueryOptions } from "@/data/firestore/types/queries";
 import { Freeplay } from "@/types/sessions/sessionTypes";
 import { infiniteQueryOptions, skipToken, useInfiniteQuery } from "@tanstack/react-query";
 import { TanstackQueryFirestorePageParam } from "../types/tanstackQueryTypes";
+import { flattenFirestoreInfiniteData } from "../utils";
 
 export function getUseFreeplayListOptions(sessionId: string | undefined, firestoreQueryOptions: FirestoreQueryOptions<FreeplayDoc> = {}) {
   return infiniteQueryOptions({
@@ -26,6 +27,7 @@ export function getUseFreeplayListOptions(sessionId: string | undefined, firesto
     initialPageParam: undefined as TanstackQueryFirestorePageParam<FreeplayDoc> | undefined,
     getPreviousPageParam: (firstPage) => firstPage.firstSnapshot ? ({ direction: 'previous' as const, snapshot: firstPage.firstSnapshot }) : undefined,
     getNextPageParam: (lastPage) => lastPage.lastSnapshot ? ({ direction: 'next' as const, snapshot: lastPage.lastSnapshot }) : undefined,
+    select: flattenFirestoreInfiniteData
   });
 }
 

--- a/src/hooks/posts/usePostList.ts
+++ b/src/hooks/posts/usePostList.ts
@@ -4,7 +4,7 @@ import { FirestoreQueryOptions } from "@/data/firestore/types/queries";
 import { Post } from "@/types/sessions/sessionTypes";
 import { infiniteQueryOptions, useInfiniteQuery } from "@tanstack/react-query";
 import { TanstackQueryFirestorePageParam } from "../types/tanstackQueryTypes";
-import { flattenFirestoreInfiniteQuery } from "../utils";
+import { flattenFirestoreInfiniteData } from "../utils";
 
 export function postListQueryOptions(firestoreQueryOptions: FirestoreQueryOptions<PostDoc> = {}) {
   return infiniteQueryOptions({
@@ -27,7 +27,7 @@ export function postListQueryOptions(firestoreQueryOptions: FirestoreQueryOption
     initialPageParam: undefined as TanstackQueryFirestorePageParam<PostDoc> | undefined,
     getPreviousPageParam: (firstPage) => firstPage.firstSnapshot ? ({ direction: 'previous' as const, snapshot: firstPage.firstSnapshot }) : undefined,
     getNextPageParam: (lastPage) => lastPage.lastSnapshot ? ({ direction: 'next' as const, snapshot: lastPage.lastSnapshot }) : undefined,
-    select: flattenFirestoreInfiniteQuery,
+    select: flattenFirestoreInfiniteData,
   });
 }
 

--- a/src/hooks/posts/usePostList.ts
+++ b/src/hooks/posts/usePostList.ts
@@ -4,6 +4,7 @@ import { FirestoreQueryOptions } from "@/data/firestore/types/queries";
 import { Post } from "@/types/sessions/sessionTypes";
 import { infiniteQueryOptions, useInfiniteQuery } from "@tanstack/react-query";
 import { TanstackQueryFirestorePageParam } from "../types/tanstackQueryTypes";
+import { flattenFirestoreInfiniteQuery } from "../utils";
 
 export function postListQueryOptions(firestoreQueryOptions: FirestoreQueryOptions<PostDoc> = {}) {
   return infiniteQueryOptions({
@@ -26,7 +27,7 @@ export function postListQueryOptions(firestoreQueryOptions: FirestoreQueryOption
     initialPageParam: undefined as TanstackQueryFirestorePageParam<PostDoc> | undefined,
     getPreviousPageParam: (firstPage) => firstPage.firstSnapshot ? ({ direction: 'previous' as const, snapshot: firstPage.firstSnapshot }) : undefined,
     getNextPageParam: (lastPage) => lastPage.lastSnapshot ? ({ direction: 'next' as const, snapshot: lastPage.lastSnapshot }) : undefined,
-    select: (data) => data.pages.flatMap(page => page.docs),
+    select: flattenFirestoreInfiniteQuery,
   });
 }
 

--- a/src/hooks/posts/usePostList.ts
+++ b/src/hooks/posts/usePostList.ts
@@ -26,6 +26,7 @@ export function postListQueryOptions(firestoreQueryOptions: FirestoreQueryOption
     initialPageParam: undefined as TanstackQueryFirestorePageParam<PostDoc> | undefined,
     getPreviousPageParam: (firstPage) => firstPage.firstSnapshot ? ({ direction: 'previous' as const, snapshot: firstPage.firstSnapshot }) : undefined,
     getNextPageParam: (lastPage) => lastPage.lastSnapshot ? ({ direction: 'next' as const, snapshot: lastPage.lastSnapshot }) : undefined,
+    select: (data) => data.pages.flatMap(page => page.docs),
   });
 }
 

--- a/src/hooks/posts/usePostList.ts
+++ b/src/hooks/posts/usePostList.ts
@@ -5,7 +5,7 @@ import { Post } from "@/types/sessions/sessionTypes";
 import { infiniteQueryOptions, useInfiniteQuery } from "@tanstack/react-query";
 import { TanstackQueryFirestorePageParam } from "../types/tanstackQueryTypes";
 
-export function getUsePostListOptions(firestoreQueryOptions: FirestoreQueryOptions<PostDoc> = {}) {
+export function postListQueryOptions(firestoreQueryOptions: FirestoreQueryOptions<PostDoc> = {}) {
   return infiniteQueryOptions({
     queryKey: ['posts', firestoreQueryOptions],
     queryFn: async ({ pageParam, client }) => {
@@ -30,5 +30,5 @@ export function getUsePostListOptions(firestoreQueryOptions: FirestoreQueryOptio
 }
 
 export default function usePostList(firestoreQueryOptions: FirestoreQueryOptions<PostDoc> = {}) {
-  return useInfiniteQuery(getUsePostListOptions(firestoreQueryOptions));
+  return useInfiniteQuery(postListQueryOptions(firestoreQueryOptions));
 }

--- a/src/hooks/programAreas/useProgramAreaList.ts
+++ b/src/hooks/programAreas/useProgramAreaList.ts
@@ -4,6 +4,7 @@ import { FirestoreQueryOptions } from "@/data/firestore/types/queries";
 import { ProgramArea } from "@/types/scheduling/schedulingTypes";
 import { infiniteQueryOptions, useInfiniteQuery } from "@tanstack/react-query";
 import { TanstackQueryFirestorePageParam } from "../types/tanstackQueryTypes";
+import { flattenFirestoreInfiniteQuery } from "../utils";
 
 export function programAreaListQueryOptions(firestoreQueryOptions: FirestoreQueryOptions<ProgramAreaDoc> = {}) {
   return infiniteQueryOptions({
@@ -26,7 +27,7 @@ export function programAreaListQueryOptions(firestoreQueryOptions: FirestoreQuer
     initialPageParam: undefined as TanstackQueryFirestorePageParam<ProgramAreaDoc> | undefined,
     getPreviousPageParam: (firstPage) => firstPage.firstSnapshot ? ({ direction: 'previous' as const, snapshot: firstPage.firstSnapshot }) : undefined,
     getNextPageParam: (lastPage) => lastPage.lastSnapshot ? ({ direction: 'next' as const, snapshot: lastPage.lastSnapshot }) : undefined,
-    select: (data) => data.pages.flatMap(page => page.docs),
+    select: flattenFirestoreInfiniteQuery,
   });
 }
 

--- a/src/hooks/programAreas/useProgramAreaList.ts
+++ b/src/hooks/programAreas/useProgramAreaList.ts
@@ -4,7 +4,7 @@ import { FirestoreQueryOptions } from "@/data/firestore/types/queries";
 import { ProgramArea } from "@/types/scheduling/schedulingTypes";
 import { infiniteQueryOptions, useInfiniteQuery } from "@tanstack/react-query";
 import { TanstackQueryFirestorePageParam } from "../types/tanstackQueryTypes";
-import { flattenFirestoreInfiniteQuery } from "../utils";
+import { flattenFirestoreInfiniteData } from "../utils";
 
 export function programAreaListQueryOptions(firestoreQueryOptions: FirestoreQueryOptions<ProgramAreaDoc> = {}) {
   return infiniteQueryOptions({
@@ -27,7 +27,7 @@ export function programAreaListQueryOptions(firestoreQueryOptions: FirestoreQuer
     initialPageParam: undefined as TanstackQueryFirestorePageParam<ProgramAreaDoc> | undefined,
     getPreviousPageParam: (firstPage) => firstPage.firstSnapshot ? ({ direction: 'previous' as const, snapshot: firstPage.firstSnapshot }) : undefined,
     getNextPageParam: (lastPage) => lastPage.lastSnapshot ? ({ direction: 'next' as const, snapshot: lastPage.lastSnapshot }) : undefined,
-    select: flattenFirestoreInfiniteQuery,
+    select: flattenFirestoreInfiniteData,
   });
 }
 

--- a/src/hooks/sections/useSectionList.ts
+++ b/src/hooks/sections/useSectionList.ts
@@ -4,6 +4,7 @@ import { FirestoreQueryOptions } from "@/data/firestore/types/queries";
 import { Section } from "@/types/sessions/sessionTypes";
 import { infiniteQueryOptions, useInfiniteQuery } from "@tanstack/react-query";
 import { TanstackQueryFirestorePageParam } from "../types/tanstackQueryTypes";
+import { flattenFirestoreInfiniteData } from "../utils";
 
 export function getUseSectionListOptions(sessionId: string, firestoreQueryOptions: FirestoreQueryOptions<SectionDoc> = {}) {
   return infiniteQueryOptions({
@@ -26,6 +27,7 @@ export function getUseSectionListOptions(sessionId: string, firestoreQueryOption
     initialPageParam: undefined as TanstackQueryFirestorePageParam<SectionDoc> | undefined,
     getPreviousPageParam: (firstPage) => firstPage.firstSnapshot ? ({ direction: 'previous' as const, snapshot: firstPage.firstSnapshot }) : undefined,
     getNextPageParam: (lastPage) => lastPage.lastSnapshot ? ({ direction: 'next' as const, snapshot: lastPage.lastSnapshot }) : undefined,
+    select: flattenFirestoreInfiniteData
   });
 }
 

--- a/src/hooks/sessions/useSessionList.ts
+++ b/src/hooks/sessions/useSessionList.ts
@@ -4,6 +4,7 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { TanstackQueryFirestorePageParam } from "../types/tanstackQueryTypes";
 import { listSessionDocs } from "@/data/firestore/sessions";
 import { Session } from "@/types/sessions/sessionTypes";
+import { flattenFirestoreInfiniteData } from "../utils";
 
 export default function useSessionList(queryOptions?: FirestoreQueryOptions<SessionDoc>) {
   return useInfiniteQuery({
@@ -26,5 +27,6 @@ export default function useSessionList(queryOptions?: FirestoreQueryOptions<Sess
     initialPageParam: undefined as TanstackQueryFirestorePageParam<SessionDoc> | undefined,
     getPreviousPageParam: (firstPage) => firstPage.firstSnapshot ? ({ direction: 'previous' as const, snapshot: firstPage.firstSnapshot }) : undefined,
     getNextPageParam: (lastPage) => lastPage.lastSnapshot ? ({ direction: 'next' as const, snapshot: lastPage.lastSnapshot }) : undefined,
+    select: flattenFirestoreInfiniteData
   });
 }

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -1,0 +1,8 @@
+import { PaginatedQueryResponse } from "@/data/firestore/types/queries"
+import { InfiniteData } from "@tanstack/react-query"
+import { TanstackQueryFirestorePageParam } from "./types/tanstackQueryTypes"
+import { DocumentData } from "firebase/firestore"
+
+export function flattenFirestoreInfiniteQuery<AppModelType, DbModelType extends DocumentData>(data: InfiniteData<PaginatedQueryResponse<AppModelType, DbModelType>, TanstackQueryFirestorePageParam<DbModelType> | undefined): AppModelType[] {
+  return data.pages.flatMap(page => page.docs);
+}

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -3,6 +3,6 @@ import { InfiniteData } from "@tanstack/react-query"
 import { TanstackQueryFirestorePageParam } from "./types/tanstackQueryTypes"
 import { DocumentData } from "firebase/firestore"
 
-export function flattenFirestoreInfiniteQuery<AppModelType, DbModelType extends DocumentData>(data: InfiniteData<PaginatedQueryResponse<AppModelType, DbModelType>, TanstackQueryFirestorePageParam<DbModelType> | undefined>): AppModelType[] {
+export function flattenFirestoreInfiniteData<AppModelType, DbModelType extends DocumentData>(data: InfiniteData<PaginatedQueryResponse<AppModelType, DbModelType>, TanstackQueryFirestorePageParam<DbModelType> | undefined>): AppModelType[] {
   return data.pages.flatMap(page => page.docs);
 }

--- a/src/hooks/utils.ts
+++ b/src/hooks/utils.ts
@@ -3,6 +3,6 @@ import { InfiniteData } from "@tanstack/react-query"
 import { TanstackQueryFirestorePageParam } from "./types/tanstackQueryTypes"
 import { DocumentData } from "firebase/firestore"
 
-export function flattenFirestoreInfiniteQuery<AppModelType, DbModelType extends DocumentData>(data: InfiniteData<PaginatedQueryResponse<AppModelType, DbModelType>, TanstackQueryFirestorePageParam<DbModelType> | undefined): AppModelType[] {
+export function flattenFirestoreInfiniteQuery<AppModelType, DbModelType extends DocumentData>(data: InfiniteData<PaginatedQueryResponse<AppModelType, DbModelType>, TanstackQueryFirestorePageParam<DbModelType> | undefined>): AppModelType[] {
   return data.pages.flatMap(page => page.docs);
 }


### PR DESCRIPTION
- Created generic function with a stable reference to flatten infinite data fetched from Firestore
  - Passed that function as the `select` in all Firestore infinite queries
- Removed `flatMap` calls from infinite query call sites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when displaying albums, album items, sessions, attendees, bunk assignments, program areas, and schedules.
  - Corrected list handling so records appear reliably across calendars, directories, activity grids, night schedules, and PDF exports.
  - Standardized loading and displaying of paginated results across the app.
  - Updated freeplay schedule generation to use the latest post-listing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->